### PR TITLE
Create python role (#48)

### DIFF
--- a/.github/workflows/molecule_tests.yml
+++ b/.github/workflows/molecule_tests.yml
@@ -8,6 +8,7 @@ jobs:
       matrix:
         role:
           - deploy_user
+          - python
           # - postgresql
     steps:
       - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ molecule[docker]
 ansible-lint
 passlib
 wheel
+yamllint

--- a/roles/python/.ansible-lint
+++ b/roles/python/.ansible-lint
@@ -1,0 +1,3 @@
+# Ignore "package installs should not use latest" error
+skip_list:
+  - 'package-latest'

--- a/roles/python/.yamllint
+++ b/roles/python/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/roles/python/README.md
+++ b/roles/python/README.md
@@ -1,0 +1,27 @@
+python
+======
+
+Installs a specified version of python and creates a virtual environment. If a `requirements.txt` file is present in the target directory, python dependencies will be installed to the newly created virtual environment.
+
+Requirements
+------------
+
+The "project" directory, where the virtual environment will be created, should exist. To specify it, set `python_app_path`. Ensure that `python_user` has permission to modify this directory and its contents.
+
+Role Variables
+--------------
+
+- `python_user`: the user account that will run python; should have access to `python_app_path`
+- `python_version`: version of python to be installed
+- `python_app_path`: location where this version of python will be used
+- `python_venv_path`: location to create the virtual environment; optional. default is `python_app_path/env`
+- `python_requirements_file`: path to `requirements.txt` file; optional. default is `python_app_path/requirements.txt`
+
+Example Playbook
+----------------
+
+```yml
+    - hosts: myapp
+      roles:
+         - { role: python, python_version: "3.8", python_user: "conan" }
+```

--- a/roles/python/defaults/main.yml
+++ b/roles/python/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# main config
+python_user: python
+python_version: "3.6"
+python_app_path: /usr/src/app
+python_venv_path: "{{ python_app_path }}/env"
+python_requirements_file: "{{ python_app_path }}/requirements.txt"

--- a/roles/python/meta/main.yml
+++ b/roles/python/meta/main.yml
@@ -1,0 +1,11 @@
+galaxy_info:
+  role_name: python
+  author: cdh
+  description: sets up python with virtual environment
+  license: Apache2
+  platforms:
+    - name: Ubuntu
+      versions:
+      - 18
+  min_ansible_version: 2.10
+dependencies: []

--- a/roles/python/molecule/default/converge.yml
+++ b/roles/python/molecule/default/converge.yml
@@ -1,0 +1,14 @@
+---
+# Run the main python task sequence for testing.
+
+- name: converge
+  hosts: all
+  gather_facts: false
+  vars_files: ../../defaults/main.yml
+  
+  tasks:
+    - name: include python role
+      include_role:
+        name: python
+      vars:
+        python_version: "3.8"

--- a/roles/python/molecule/default/molecule.yml
+++ b/roles/python/molecule/default/molecule.yml
@@ -1,0 +1,20 @@
+---
+dependency:
+  name: galaxy
+  enabled: false
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: pulibrary/puldocker-ubuntu1804-ansible:latest
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  log: true
+verifier:
+  name: ansible
+lint: |
+  set -e
+  yamllint .
+  ansible-lint

--- a/roles/python/molecule/default/prepare.yml
+++ b/roles/python/molecule/default/prepare.yml
@@ -1,0 +1,26 @@
+---
+# Create a project directory and requirements file for testing.
+
+- name: prepare
+  hosts: all
+  gather_facts: false
+  vars_files: ../../defaults/main.yml
+  
+  tasks:
+    - name: create a testing user
+      user:
+        name: "{{ python_user }}"
+
+    - name: create project directory
+      file:
+        path: "{{ python_app_path }}"
+        state: directory
+        owner: "{{ python_user }}"
+        mode: 0744
+
+    - name: create requirements.txt file
+      copy:
+        dest: "{{ python_requirements_file }}"
+        content: Django==3.1
+        owner: "{{ python_user }}"
+        mode: 0644

--- a/roles/python/molecule/default/verify.yml
+++ b/roles/python/molecule/default/verify.yml
@@ -1,0 +1,29 @@
+---
+# Tests for python role.
+
+- name: verify
+  hosts: all
+  gather_facts: false
+  vars_files: ../../defaults/main.yml
+
+  tasks:
+    - name: check python version in virtual environment
+      command: "{{ python_venv_path }}/bin/python --version"
+      register: _python_version
+      changed_when: true
+
+    - name: python version should be 3.8
+      assert:
+        that: _python_version.stdout.startswith("Python 3.8")
+
+    - name: check installed packages in virtual environment
+      pip:
+        name: Django
+        virtualenv: "{{ python_venv_path }}"
+      check_mode: true
+      register: _installed_pkgs
+      changed_when: true
+
+    - name: django should be v3.1 in virtual environment
+      assert:
+        that: "'Django==3.1' in _installed_pkgs.stdout_lines"

--- a/roles/python/tasks/install_dependencies.yml
+++ b/roles/python/tasks/install_dependencies.yml
@@ -1,0 +1,29 @@
+---
+# Create a virtual environment and update pip/setuptools. If a requirements.txt
+# file is present, install its contents into the virtual environment.
+
+- name: upgrade pip/setuptools
+  become: true
+  become_user: "{{ python_user }}"
+  pip:
+    virtualenv: "{{ python_venv_path }}"
+    virtualenv_command: python{{ python_version }} -m venv
+    name:
+      - pip
+      - setuptools
+    state: latest
+
+- name: check for requirements.txt file
+  become: true
+  become_user: "{{ python_user }}"
+  stat:
+    path: "{{ python_requirements_file }}"
+  register: _requirements_file
+
+- name: install python requirements
+  when: _requirements_file.stat.exists
+  become: true
+  become_user: "{{ python_user }}"
+  pip:
+    virtualenv: "{{ python_venv_path }}"
+    requirements: "{{ python_requirements_file }}"

--- a/roles/python/tasks/install_python.yml
+++ b/roles/python/tasks/install_python.yml
@@ -1,0 +1,26 @@
+---
+# Install a specified version of python. Uses a repository that provides newer
+# versions of python, since Ubuntu doesn't (deadsnakes).
+# 
+# Note that Ubuntu splits up core python libraries into many packages; most are
+# required to create the venv. Contents may differ depending on the version of
+# python – for example, python3.8-distutils falls back to python3-distutils.
+# 
+# We include the generic python3-setuptools because it's required to create the
+# virtual environment; later we can update pip and setuptools inside it.
+
+- name: add python apt repository
+  become: true
+  apt_repository:
+    repo: ppa:deadsnakes/ppa
+
+- name: install python and core libraries
+  become: true
+  apt:
+    name:
+      - python3-setuptools
+      - python{{ python_version }}
+      - python{{ python_version }}-venv
+      - python{{ python_version }}-distutils
+    state: latest
+    update_cache: true

--- a/roles/python/tasks/main.yml
+++ b/roles/python/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# Basic sequence of tasks for setting up a Python app.
+
+- include: install_python.yml
+- include: install_dependencies.yml


### PR DESCRIPTION
In writing the django role (#63) it turned out that the only real dependency was python itself; I ended up making a simple role to take care of installing the desired version and create a virtual environment. This is equivalent to our `build_virtualenv` role but for PUL environments, and with a little more functionality.

- Adds a simple role that can install desired python version (including newer versions not in ubuntu repository)
<s>- Role updates symlinks so `python` works correctly in terminal</s>
- Role can create a virtual environment and install dependencies

If we specify this role as a dependency of the `django` role with the following defaults:
```yml
python_app_path: "{{ django_app_path }}"
python_requirements_path: "{{ django_app_path }}/requirements.txt"
```
Then playbooks that use django need only specify `python_version` and do:
```yml
include_role: django
```
And python + the virtual environment + dependencies will be set up automatically, without needing to explicitly include the `python` role.
