### PR TITLE
ppa node fixes

### DIFF
--- a/group_vars/ppa/vars.yml
+++ b/group_vars/ppa/vars.yml
@@ -2,11 +2,11 @@
 # Variables for PPA that apply across all deploy groups (prod, qa, and staging)
 ###
 ---
-# Using python35 and nodejs8 for QA and staging
+# Using python35 and nodejs10 for QA and staging
 # Paths are picky and spaces for any YAML multiline syntax causes issues
-path: '/opt/rh/rh-python35/root/usr/bin:/opt/rh/rh-nodejs8/root/usr/bin:{{ ansible_env.PATH }}'
-ld_library_path: '/opt/rh/rh-python35/root/usr/lib64:/opt/rh/rh-nodejs8/root/usr/lib64{% if ansible_env.LD_LIBRARY_PATH is defined %}:{{ ansible_env.LD_LIBRARY_PATH }}{% endif %}'
-python_path: '/opt/rh/rh-nodejs8/root/usr/lib/python2.7/site-packages{% if ansible_env.PYTHON_PATH is defined %}:{{ ansible_env.PYTHONPATH }}{% endif %}'
+path: '/opt/rh/rh-python35/root/usr/bin:/opt/rh/rh-nodejs10/root/usr/bin:{{ ansible_env.PATH }}'
+ld_library_path: '/opt/rh/rh-python35/root/usr/lib64:/opt/rh/rh-nodejs10/root/usr/lib64{% if ansible_env.LD_LIBRARY_PATH is defined %}:{{ ansible_env.LD_LIBRARY_PATH }}{% endif %}'
+python_path: '/opt/rh/rh-nodejs10/root/usr/lib/python2.7/site-packages{% if ansible_env.PYTHON_PATH is defined %}:{{ ansible_env.PYTHONPATH }}{% endif %}'
 # Github repository
 repo: 'Princeton-CDH/ppa-django'
 app_name: ppa

--- a/group_vars/ppa_prod/vars.yml
+++ b/group_vars/ppa_prod/vars.yml
@@ -8,6 +8,6 @@ allowed_hosts:
 email_prefix: '[PPA] '
 
 # running on python 3.6 in production
-path: '/opt/rh/rh-python36/root/usr/bin:/opt/rh/rh-nodejs8/root/usr/bin:{{ ansible_env.PATH }}'
-ld_library_path: '/opt/rh/rh-python36/root/usr/lib64:/opt/rh/rh-nodejs8/root/usr/lib64{% if ansible_env.LD_LIBRARY_PATH is defined %}:{{ ansible_env.LD_LIBRARY_PATH }}{% endif %}'
+path: '/opt/rh/rh-python36/root/usr/bin:/opt/rh/rh-nodejs10/root/usr/bin:{{ ansible_env.PATH }}'
+ld_library_path: '/opt/rh/rh-python36/root/usr/lib64:/opt/rh/rh-nodejs10/root/usr/lib64{% if ansible_env.LD_LIBRARY_PATH is defined %}:{{ ansible_env.LD_LIBRARY_PATH }}{% endif %}'
 media_root: '/srv/www/prod/media'

--- a/roles/build_npm/tasks/main.yml
+++ b/roles/build_npm/tasks/main.yml
@@ -22,6 +22,7 @@
       become_user: "{{ deploy_user }}"
       npm:
         path: "{{ deploy }}"
+        ci: true
 
   rescue:
     - include_tasks: roles/create_deployment/tasks/fail.yml


### PR DESCRIPTION
Two changes I needed to successfully deploy PPA to QA. We specified node v10 in the README, but weren't actually using it on VMs. I also got an unpredictable version of `node-sass` that was too new to be compatible with node v10 despite a correct `package-lock.json`, which I determined was because we weren't using `npm ci` to install js dependencies during the deploy.

- Use nodejs v10 for PPA
- Ensure build_npm role installs from package-lock.json
