### PR TITLE
Use git shallow branch clone instead of rsync #86

### DIFF
--- a/group_vars/ppa_qa/vars.yml
+++ b/group_vars/ppa_qa/vars.yml
@@ -7,3 +7,7 @@ project_user: ppa
 symlink: ppa-django
 media_root: '/srv/www/qa/ppa-django/media'
 marc_data_path: '/srv/www/qa/ppa-django/data/marc/'
+# python in qa is still 3.5 even though ppa is 3.6 in production :=(
+python_version: "python3.5"
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-ansible>=3.3
-ansible-base
+ansible>=4.3
 molecule[docker]
 ansible-lint
 passlib

--- a/roles/build_project_repo/tasks/main.yml
+++ b/roles/build_project_repo/tasks/main.yml
@@ -53,16 +53,17 @@
         state: directory
         dest: "{{ deploy }}"
 
-    - name: Sync checkout to deploy directory
+    # using the local git repository as source, do a shallow, single branch checkout
+    # for the deployed instance
+    - name: Create a shallow checkout of deploy branch to deploy directory
       become: true
       become_user: "{{ deploy_user }}"
-      synchronize:
-        src: "{{ clone_root }}/{{ repo }}/"
-        # deploy constructed dynamicallly in group_vars
+      git:
+        repo: "{{ clone_root }}/{{ repo }}"
         dest: "{{ deploy }}/"
-      # sync remotely -- inventory_hostname is a magic var that always points
-      # to host where the playbook is being run.
-      delegate_to: "{{ inventory_hostname }}"
+        version: "{{ gitref }}"
+        single_branch: true
+        depth: 1
 
   rescue:
     - include_tasks: roles/create_deployment/tasks/fail.yml


### PR DESCRIPTION
I replaced just the rsync step with the git shallow clone, because that's the smallest change that addresses the immediate problem. We could probably replace the full repo checkout (which is what I think you were proposing); I'm just not sure what the implications are and hesitant to make a bigger change for our springdale deploys.

I think Ben's idea with the original setup is that we only have to clone the full repo once, and then once we have it we will only need to pull in incremental changes. I don't actually know if that's any faster than just doing a shallow checkout of the particular version we want.

I had to upgrade ansible to get a version that supported the git options I wanted to use.

Have tested this deploy on both cdh-web qa and derrida qa.