### PR TITLE
Add path for git 2.27 to springdale deploys

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -59,11 +59,11 @@ logging_dir: '{{ install_root }}/logs'
 # logging file
 logging_path: '{{ logging_dir }}/{{ django_app }}.log'
 
-# These include the path for rh-python35 and nodejs6
+# These include the path for rh-python35, nodejs6, and git 2.27
 # Paths are picky and spaces for any YAML multiline syntax cause issues
 # These are defaults for most projects and should be overriden as necessary.
 path: '/opt/rh/rh-python35/root/usr/bin:/opt/rh/rh-nodejs6/root/usr/bin:/opt/rh/rh-git227/root/bin/:{{ ansible_env.PATH }}'
-ld_library_path: '/opt/rh/rh-python35/root/usr/lib64:/opt/rh/rh-nodejs6/root/usr/lib64{% if ansible_env.LD_LIBRARY_PATH is defined %}:{{ ansible_env.LD_LIBRARY_PATH }}{% endif %}'
+ld_library_path: '/opt/rh/rh-python35/root/usr/lib64:/opt/rh/rh-nodejs6/root/usr/lib64:/opt/rh/httpd24/root/usr/lib64{% if ansible_env.LD_LIBRARY_PATH is defined %}:{{ ansible_env.LD_LIBRARY_PATH }}{% endif %}'
 python_path: '/opt/rh/rh-nodejs6/root/usr/lib/python2.7/site-packages{% if ansible_env.PYTHON_PATH is defined %}:{{ ansible_env.PYTHONPATH }}{% endif %}'
 
 # currently default for most projects is 3.5

--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -62,7 +62,7 @@ logging_path: '{{ logging_dir }}/{{ django_app }}.log'
 # These include the path for rh-python35 and nodejs6
 # Paths are picky and spaces for any YAML multiline syntax cause issues
 # These are defaults for most projects and should be overriden as necessary.
-path: '/opt/rh/rh-python35/root/usr/bin:/opt/rh/rh-nodejs6/root/usr/bin:{{ ansible_env.PATH }}'
+path: '/opt/rh/rh-python35/root/usr/bin:/opt/rh/rh-nodejs6/root/usr/bin:/opt/rh/rh-git227/root/bin/:{{ ansible_env.PATH }}'
 ld_library_path: '/opt/rh/rh-python35/root/usr/lib64:/opt/rh/rh-nodejs6/root/usr/lib64{% if ansible_env.LD_LIBRARY_PATH is defined %}:{{ ansible_env.LD_LIBRARY_PATH }}{% endif %}'
 python_path: '/opt/rh/rh-nodejs6/root/usr/lib/python2.7/site-packages{% if ansible_env.PYTHON_PATH is defined %}:{{ ansible_env.PYTHONPATH }}{% endif %}'
 

--- a/group_vars/mep/vars.yml
+++ b/group_vars/mep/vars.yml
@@ -18,7 +18,7 @@ paris_overlay: 'https://tiles.arcgis.com/tiles/4Ko8f1mCWFLyY4NV/arcgis/rest/serv
 # Paths are picky and spaces for any YAML multiline syntax cause issues
 # These are defaults for most projects and should be overriden as necessary.
 path: '/opt/rh/rh-python35/root/usr/bin:/opt/rh/rh-nodejs8/root/usr/bin:/opt/rh/rh-git227/root/bin/:{{ ansible_env.PATH }}'
-ld_library_path: '/opt/rh/rh-python35/root/usr/lib64:/opt/rh/rh-nodejs8/root/usr/lib64{% if ansible_env.LD_LIBRARY_PATH is defined %}:{{ ansible_env.LD_LIBRARY_PATH }}{% endif %}'
+ld_library_path: '/opt/rh/rh-python35/root/usr/lib64:/opt/rh/rh-nodejs8/root/usr/lib64:/opt/rh/httpd24/root/usr/lib64{% if ansible_env.LD_LIBRARY_PATH is defined %}:{{ ansible_env.LD_LIBRARY_PATH }}{% endif %}'
 python_path: '/opt/rh/rh-nodejs8/root/usr/lib/python2.7/site-packages{% if ansible_env.PYTHON_PATH is defined %}:{{ ansible_env.PYTHONPATH }}{% endif %}'
 
 # - solr settings

--- a/group_vars/mep/vars.yml
+++ b/group_vars/mep/vars.yml
@@ -17,7 +17,7 @@ paris_overlay: 'https://tiles.arcgis.com/tiles/4Ko8f1mCWFLyY4NV/arcgis/rest/serv
 # These include the path for rh-python35 and nodejs8
 # Paths are picky and spaces for any YAML multiline syntax cause issues
 # These are defaults for most projects and should be overriden as necessary.
-path: '/opt/rh/rh-python35/root/usr/bin:/opt/rh/rh-nodejs8/root/usr/bin:{{ ansible_env.PATH }}'
+path: '/opt/rh/rh-python35/root/usr/bin:/opt/rh/rh-nodejs8/root/usr/bin:/opt/rh/rh-git227/root/bin/:{{ ansible_env.PATH }}'
 ld_library_path: '/opt/rh/rh-python35/root/usr/lib64:/opt/rh/rh-nodejs8/root/usr/lib64{% if ansible_env.LD_LIBRARY_PATH is defined %}:{{ ansible_env.LD_LIBRARY_PATH }}{% endif %}'
 python_path: '/opt/rh/rh-nodejs8/root/usr/lib/python2.7/site-packages{% if ansible_env.PYTHON_PATH is defined %}:{{ ansible_env.PYTHONPATH }}{% endif %}'
 

--- a/group_vars/ppa/vars.yml
+++ b/group_vars/ppa/vars.yml
@@ -5,7 +5,7 @@
 # Using python35 and nodejs10 for QA and staging
 # Paths are picky and spaces for any YAML multiline syntax causes issues
 path: '/opt/rh/rh-python35/root/usr/bin:/opt/rh/rh-nodejs10/root/usr/bin:/opt/rh/rh-git227/root/bin:{{ ansible_env.PATH }}'
-ld_library_path: '/opt/rh/rh-python35/root/usr/lib64:/opt/rh/rh-nodejs10/root/usr/lib64{% if ansible_env.LD_LIBRARY_PATH is defined %}:{{ ansible_env.LD_LIBRARY_PATH }}{% endif %}'
+ld_library_path: '/opt/rh/rh-python35/root/usr/lib64:/opt/rh/rh-nodejs10/root/usr/lib64:/opt/rh/httpd24/root/usr/lib64{% if ansible_env.LD_LIBRARY_PATH is defined %}:{{ ansible_env.LD_LIBRARY_PATH }}{% endif %}'
 python_path: '/opt/rh/rh-nodejs10/root/usr/lib/python2.7/site-packages{% if ansible_env.PYTHON_PATH is defined %}:{{ ansible_env.PYTHONPATH }}{% endif %}'
 # Github repository
 repo: 'Princeton-CDH/ppa-django'

--- a/group_vars/ppa/vars.yml
+++ b/group_vars/ppa/vars.yml
@@ -4,7 +4,7 @@
 ---
 # Using python35 and nodejs10 for QA and staging
 # Paths are picky and spaces for any YAML multiline syntax causes issues
-path: '/opt/rh/rh-python35/root/usr/bin:/opt/rh/rh-nodejs10/root/usr/bin:{{ ansible_env.PATH }}'
+path: '/opt/rh/rh-python35/root/usr/bin:/opt/rh/rh-nodejs10/root/usr/bin:/opt/rh/rh-git227/root/bin:{{ ansible_env.PATH }}'
 ld_library_path: '/opt/rh/rh-python35/root/usr/lib64:/opt/rh/rh-nodejs10/root/usr/lib64{% if ansible_env.LD_LIBRARY_PATH is defined %}:{{ ansible_env.LD_LIBRARY_PATH }}{% endif %}'
 python_path: '/opt/rh/rh-nodejs10/root/usr/lib/python2.7/site-packages{% if ansible_env.PYTHON_PATH is defined %}:{{ ansible_env.PYTHONPATH }}{% endif %}'
 # Github repository

--- a/group_vars/ppa_prod/vars.yml
+++ b/group_vars/ppa_prod/vars.yml
@@ -8,7 +8,7 @@ allowed_hosts:
 email_prefix: '[PPA] '
 
 # running on python 3.6 in production
-path: '/opt/rh/rh-python36/root/usr/bin:/opt/rh/rh-nodejs10/root/usr/bin:{{ ansible_env.PATH }}'
+path: '/opt/rh/rh-python36/root/usr/bin:/opt/rh/rh-nodejs10/root/usr/bin:/opt/rh/rh-git227/root/bin/:{{ ansible_env.PATH }}'
 ld_library_path: '/opt/rh/rh-python36/root/usr/lib64:/opt/rh/rh-nodejs10/root/usr/lib64{% if ansible_env.LD_LIBRARY_PATH is defined %}:{{ ansible_env.LD_LIBRARY_PATH }}{% endif %}'
 media_root: '/srv/www/prod/media'
 marc_data_path: '/srv/www/prod/data/marc/'

--- a/group_vars/ppa_prod/vars.yml
+++ b/group_vars/ppa_prod/vars.yml
@@ -9,7 +9,7 @@ email_prefix: '[PPA] '
 
 # running on python 3.6 in production
 path: '/opt/rh/rh-python36/root/usr/bin:/opt/rh/rh-nodejs10/root/usr/bin:/opt/rh/rh-git227/root/bin/:{{ ansible_env.PATH }}'
-ld_library_path: '/opt/rh/rh-python36/root/usr/lib64:/opt/rh/rh-nodejs10/root/usr/lib64{% if ansible_env.LD_LIBRARY_PATH is defined %}:{{ ansible_env.LD_LIBRARY_PATH }}{% endif %}'
+ld_library_path: '/opt/rh/rh-python36/root/usr/lib64:/opt/rh/rh-nodejs10/root/usr/lib64:/opt/rh/httpd24/root/usr/lib64{% if ansible_env.LD_LIBRARY_PATH is defined %}:{{ ansible_env.LD_LIBRARY_PATH }}{% endif %}'
 media_root: '/srv/www/prod/media'
 marc_data_path: '/srv/www/prod/data/marc/'
 


### PR DESCRIPTION
Adding the git 2.27 path for springdale deploys

Because of the way our builds & paths are configured, this currently has to be set in multiple places

~I'm not sure it's actually working correctly; tested it with ppa in qa and still got the warning that the git version is too old for the options we're using.~
I had a path wrong for ppa, and I did not know I needed to also include a new LD_LIBRARY_PATH; I added those and the new deploy worked correctly for PPA in QA