### PR TITLE
296c configure driver timeout

### DIFF
--- a/group_vars/derrida_crawl_qa/vars.yml
+++ b/group_vars/derrida_crawl_qa/vars.yml
@@ -12,6 +12,10 @@ browsertrix_crawl_repo_branch: staging
 browsertrix_collection: "derrida"
 browsertrix_custom_driver: "derrida-driver.js"
 
+# Set at 5 hours to ensure that the custom driver can finish hovering over all
+#  visualization elements
+browsertrix_timeout_seconds: 18000
+
 # configure urls to be set in the browsertrix crawl config
 browsertrix_crawl_seeds:
    - url: "https://derridas-margins.princeton.edu/"

--- a/roles/browsertrix/README.md
+++ b/roles/browsertrix/README.md
@@ -18,6 +18,7 @@ Role Variables
 - `browsertrix_crawl_repo_branch`: branch of the GitHub repository; default is `main`
 - `browsertrix_collection`: collection name to be used for the archive (optional)
 - `browsertrix_custom_driver`: custom driver to pass to browsertrix for specific interactive behaviors (optional)
+- `browsertrix_timeout_seconds`: number of seconds before browsertrix gives up trying to load a URL (optional)
 
 
 Dependencies

--- a/roles/browsertrix/files/derrida-driver.js
+++ b/roles/browsertrix/files/derrida-driver.js
@@ -6,9 +6,8 @@ module.exports = async ({ data, page, crawler }) => {
   // to load & archive the ajax reference card
   const markers = await page.$$('.visualization-chapter-marker')
   for (let count = 0; count < markers.length; count++) {
-    await crawler.sleep(1000);
     await markers[count].hover();
-    await crawler.sleep(3000);
+    await crawler.sleep(2000);
   }
 
   // for image display, toggle to deep zoom mode to

--- a/roles/browsertrix/templates/crawl.sh.j2
+++ b/roles/browsertrix/templates/crawl.sh.j2
@@ -9,8 +9,9 @@ sudo docker run -v {{ browsertrix_crawl_config_dest }}:/app/crawl-config.yaml \
     --config /app/crawl-config.yaml --rolloverSize 50000000 \
     --useSitemap \
     --workers {{ browsertrix_worker_count }} \
-    {% if browsertrix_collection is defined %}--collection {{ browsertrix_collection }}{% endif %} \
-    {% if browsertrix_custom_driver is defined %}--driver /app/custom-driver.js {% endif %}
+    {% if browsertrix_timeout_seconds is defined %}--timeout {{ browsertrix_timeout_seconds  }} \
+    {% endif %}{% if browsertrix_collection is defined %}--collection {{ browsertrix_collection }} \
+    {% endif %}{% if browsertrix_custom_driver is defined %}--driver /app/custom-driver.js {% endif %}
 
 # change collection files owner from root to ansible user
 sudo chown -R {{ ansible_user }}.{{ ansible_user }} {{ browsertrix_crawl_dir }}


### PR DESCRIPTION
https://github.com/Princeton-CDH/derrida-django/issues/296

Yay, it works! Two changes that are in this PR that is different from my last run of the crawl:
* I've shortened the sleep before and after a hover. I'm guessing that the reason it didn't work before was not because of load time but because of the URL timing out.
* I'm not including the `--behaviorTimeout`. I think it was specific to non-custom driver features? I didn't fully understand the documentation.

In case we need to go back, here is the docker command that was successful:
```sh
# script to kick off browsertrix crawl with yaml config
# docker commands need to be run as root unless otherwise configured
sudo docker run -v /home/pulsys/crawl-config.yaml:/app/crawl-config.yaml \
    -v /home/pulsys/crawls:/crawls/ \
     -v /home/pulsys/custom-driver.js:/app/custom-driver.js \
     webrecorder/browsertrix-crawler crawl \
    --config /app/crawl-config.yaml --rolloverSize 50000000 \
    --useSitemap \
    --workers 2 \
    --behaviorTimeout 0 \
    --timeout 18000 \
    --collection derrida \
    --driver /app/custom-driver.js
```