### PR TITLE
Skip setup tasks by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ ansible-playbook -e ref=GITREF playbooks/name_of_playbook.yml
 
 The playbook will run, noting success and failures. The `-v` flag adjusts verbosity (adding more `v`s will produce more verbosity. Debug tasks are usually written at `2`)
 
+### Skip setup tasks
+
+By default, initial provisioning and setup tasks are configured to be skipped.  Tasks or groups of tasks should be tagged as `setup`.
+
+To run playbook without skipping setup tasks, override the default skip tag configuration:
+
+```{bash}
+ansible-playbook playbooks/name_of_playbook.yml --skip-tags none
+```
+
 ## Revert last deploy
 
 To revert to previous deploy run call the `revert_deploy` playbook with a `host_group` matching the deploy you want to revert, e.g.:

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -9,3 +9,6 @@ interpreter_python=/usr/bin/python3
 
 [ssh-connection]
 pipelining=true
+
+[tags]
+skip=setup

--- a/roles/build_dependencies/tasks/main.yml
+++ b/roles/build_dependencies/tasks/main.yml
@@ -3,12 +3,14 @@
 # https://github.com/phusion/passenger/issues/2303#issuecomment-931571362
 - name: update ca certificates
   become: true
+  tags: setup
   apt:
     name: "ca-certificates"
     state: latest
 
 - name: install configured dependencies
   become: true
+  tags: setup
   apt:
     name: "{{ common_dependencies + app_dependencies }}"
     state: present
@@ -18,6 +20,7 @@
 
 - name: configure tmux
   become: true
+  tags: setup
   copy:
     src: "tmux.conf"
     dest: "/etc/tmux.conf"

--- a/roles/build_npm/tasks/main.yml
+++ b/roles/build_npm/tasks/main.yml
@@ -7,9 +7,10 @@
 ---
 - name: npm configuration tasks
   block:
-  
+
     - name: ensure nodejs and package managers are installed
       become: true
+      tags: setup
       community.general.snap:
         name: node
         classic: true

--- a/roles/build_project_repo/tasks/main.yml
+++ b/roles/build_project_repo/tasks/main.yml
@@ -16,6 +16,7 @@
       when: ansible_distribution == 'Springdale'
 
     - name: Ensure deploy user has access to install root
+      tags: setup
       become: true
       file:
         dest: "{{ install_root }}"
@@ -51,6 +52,7 @@
 
     - name: Create the deploy directory (to recursively create parent dirs if necessary)
       become: true
+      tags: setup
       become_user: "{{ deploy_user }}"
       file:
         state: directory

--- a/roles/configure_logging/tasks/main.yml
+++ b/roles/configure_logging/tasks/main.yml
@@ -3,6 +3,7 @@
 # Apache to write log files for the Django application.
 ###
 - name: Set up and configure logging
+  tags: setup
   become: "{{ 'true' if ansible_distribution != 'Springdale' else 'false' }}"
   block:
     - name: Create logging directory

--- a/roles/configure_media/tasks/main.yml
+++ b/roles/configure_media/tasks/main.yml
@@ -5,12 +5,14 @@
   become: "{{ 'true' if ansible_distribution != 'Springdale' else 'false' }}"
   block:
     - name: Create media root if it does not already exist
+      tags: setup
       file:
         path: "{{ media_root }}"
         state: directory
         mode: "u=rwX,g=rwX,o=X"
 
     - name: Make sure media root is owned by apache user and group
+      tags: setup
       file:
         path: "{{ media_root }}"
         owner: "{{ apache_user }}"
@@ -20,6 +22,7 @@
       when: ansible_distribution == 'Ubuntu'
 
     - name: if on qa, set acls appropriately so apache can access
+      tags: setup
       acl:
         entity: "{{ apache_group }}"
         etype: group
@@ -31,6 +34,7 @@
       when: qa is defined
 
     - name: Give deploy acl rwx over all files in the directory as a fall back
+      tags: setup
       acl:
         entity: "{{ deploy_user }}"
         etype: user

--- a/roles/deploy_user/tasks/main.yml
+++ b/roles/deploy_user/tasks/main.yml
@@ -2,6 +2,7 @@
 # tasks file for deploy_user
 - name: set up deploy user
   become: true
+  tags: setup
   block:
     - name: create deploy user group
       group:

--- a/roles/django/tasks/compilemessages.yml
+++ b/roles/django/tasks/compilemessages.yml
@@ -4,6 +4,7 @@
 
 - name: ensure gnu gettext is installed
   become: true
+  tags: setup
   apt:
     name: gettext
     state: present

--- a/roles/passenger/tasks/main.yml
+++ b/roles/passenger/tasks/main.yml
@@ -8,35 +8,41 @@
       include_vars: "main.yml"
 
     - name: Define nginx_user.
+      tags: setup
       set_fact:
         nginx_user: "{{ __nginx_user }}"
       when: nginx_user is not defined
 
     # Passenger repository setup.
     - name: Add Passenger apt key.
+      tags: setup
       apt_key:
         keyserver: keyserver.ubuntu.com
         id: 561F9B9CAC40B2F7
         state: present
 
     - name: Add apt HTTPS capabilities.
+      tags: setup
       apt:
         name: apt-transport-https
         state: present
 
     - name: Add Phusion apt repo.
+      tags: setup
       apt_repository:
         repo: 'deb https://oss-binaries.phusionpassenger.com/apt/passenger {{ ansible_distribution_release }} main'
         state: present
       ignore_errors: true
 
     - name: update our repos
+      tags: setup
       become: true
       apt:
         update_cache: true
 
     # Nginx and passenger installation.
     - name: Install Nginx and Passenger.
+      tags: setup
       become: true
       apt:
         name: "{{ nginx_passenger_packages }}"

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -4,18 +4,21 @@
 
 - name: make sure the CA certificates are available
   become: true
+  tags: setup
   apt:
     pkg: ca-certificates
     state: present
 
 - name: add postgres repository apt-key
   become: true
+  tags: setup
   apt_key:
     url: "{{ postgres_apt_key_url }}"
     state: present
 
 - name: add postgres repository
   become: true
+  tags: setup
   apt_repository:
     repo: "{{ postgres_apt_repository }}"
     update_cache: true
@@ -23,6 +26,7 @@
 
 - name: install postgres client libraries
   become: true
+  tags: setup
   apt:
     name: "{{ item }}"
     state: present
@@ -34,6 +38,7 @@
     - postgresql-client-{{ postgres_version }}
 
 - name: ensure access to postgres server
+  tags: setup
   become: true
   lineinfile:
     path: "/etc/postgresql/{{ postgres_version }}/main/pg_hba.conf"
@@ -42,6 +47,7 @@
 
 - name: reload remote postgres server
   become: true
+  tags: setup
   service:
     name: postgresql
     state: reloaded

--- a/roles/solr_collection/tasks/main.yml
+++ b/roles/solr_collection/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 # tasks file for roles/solr_collection
 - name: Create the base directory for Solr configsets
+  tags: setup
   file:
     path: "/solr/cdh_solr/"
     state: directory


### PR DESCRIPTION
- tagged one-time setup / provisioning tasks with tag `setup`
- configured setup tag to be skipped by default in ansible config
- updated readme to document the behavior and command to run playbook with setup tasks 

molecule tests are failing, but I think it's not related to these changes... (maybe the keyserver issue? or maybe just got out of date...)