### PR TITLE
Switch prosody deploy from apache2 to nginx/passenger

### DIFF
--- a/group_vars/prosody/vars.yml
+++ b/group_vars/prosody/vars.yml
@@ -28,7 +28,7 @@ apache_app_path: "/var/www/{{ app_name }}"
 
 # set passenger defaults for production; override for other environments
 passenger_app_root: "/var/www/{{ app_name }}"
-passenger_server_name: "geniza.princeton.edu"
+passenger_server_name: "prosody.princeton.edu"
 passenger_startup_file: "{{ app_name }}/wsgi.py"
 passenger_python: "{{ passenger_app_root }}/env/bin/python"
 

--- a/group_vars/prosody/vars.yml
+++ b/group_vars/prosody/vars.yml
@@ -11,8 +11,8 @@ django_app: ppa
 symlink: ppa
 # wsgi file relative to deploy location
 wsgi_path: "{{ django_app }}/wsgi.py"
-# use python 3.6
-python_version: 3.6
+# use python 3.9
+python_version: 3.9
 # nodejs version
 node_version: "10"
 

--- a/group_vars/prosody/vars.yml
+++ b/group_vars/prosody/vars.yml
@@ -26,6 +26,13 @@ install_root: "/srv/www/{{ app_name }}"
 # apache location
 apache_app_path: "/var/www/{{ app_name }}"
 
+# set passenger defaults for production; override for other environments
+passenger_app_root: "/var/www/{{ app_name }}"
+passenger_server_name: "geniza.princeton.edu"
+passenger_startup_file: "{{ app_name }}/wsgi.py"
+passenger_python: "{{ passenger_app_root }}/env/bin/python"
+
+
 # base data dir — easier if NOT under conan home directory
 data_path: "/srv/www/data"
 # path to hathitree pairtree data

--- a/group_vars/prosody_qa/vars.yml
+++ b/group_vars/prosody_qa/vars.yml
@@ -4,7 +4,9 @@
 ---
 
 # email prefix for dev account emails
-email_prefix: '[PPA S&co] '
+email_prefix: '[PPA QA] '
+
+passenger_server_name: "test-ppa.cdh.princeton.edu"
 
 # solr settings
 # NOTE: should be moved somewhere common; zk is unique but solr vars used for old deploys

--- a/playbooks/prosody.yml
+++ b/playbooks/prosody.yml
@@ -16,6 +16,7 @@
     - build_dependencies
     - build_project_repo
     - postgresql
+    - passenger
     - build_npm
     - build_semantic
     - run_webpack   # dependency for collectstatic
@@ -23,6 +24,5 @@
     - django
     - solr_collection
     - prosody_setup
-    - configure_apache
     - finalize_deploy
     - close_deployment

--- a/playbooks/prosody_qa.yml
+++ b/playbooks/prosody_qa.yml
@@ -16,6 +16,7 @@
     - build_dependencies
     - build_project_repo
     - postgresql
+    - passenger
     - build_npm
     - build_semantic
     - run_webpack   # dependency for collectstatic
@@ -23,6 +24,5 @@
     - django
     - solr_collection
     - prosody_setup
-    - configure_apache
     - finalize_deploy
     - close_deployment

--- a/roles/passenger/handlers/main.yml
+++ b/roles/passenger/handlers/main.yml
@@ -1,7 +1,16 @@
 ---
+# to automate transition from apache to nginx:
+# handler to stop and disable apache if the service is defined
+- name: Stop apache2
+  ansible.builtin.service:
+    name: apache2
+    enabled: false
+    state: stopped
+
 - name: Restart nginx
   become: true
   ansible.builtin.service:
     name: nginx
     state: restarted
   listen: "restart web server"
+

--- a/roles/passenger/tasks/main.yml
+++ b/roles/passenger/tasks/main.yml
@@ -66,7 +66,9 @@
         src: "{{ passenger_nginx_site_template }}"
         dest: /etc/nginx/sites-available/{{ passenger_site_config_name }}.conf
         mode: 0644
-      notify: Restart nginx
+      notify:
+        - Stop apache2
+        - Restart nginx
 
     - name: Ensure passenger virtual host is enabled.
       ansible.builtin.file:
@@ -81,4 +83,5 @@
         mode: 0644
       when: nginx_remove_default_vhost
       notify:
+        - Stop apache2
         - Restart nginx


### PR DESCRIPTION
per https://github.com/Princeton-CDH/ppa-django/issues/501

in this pr:
- cherry-picked the python version change from the other branch
- revise prosody playbooks to remove apache role and add passenger
- add passenger config variables for prosody and prosody qa
- add handler to passenger to ensure that apache2 is not running when we restart nginx