### PR TITLE
Enable Arabic on Geniza public site settings

### DIFF
--- a/roles/django/templates/geniza_settings.py
+++ b/roles/django/templates/geniza_settings.py
@@ -51,7 +51,7 @@ WARNING_BANNER_MESSAGE = "{{ warning_banner_message }}"
 PUBLIC_SITE_LANGUAGES = [
    "en",
    "he",
-#    "ar",
+   "ar",
 ]
 {% endblock %}
 


### PR DESCRIPTION
This PR simply uncomments Arabic on the list of public site languages for Geniza.