### PR TITLE
Add an optional pause before finalizing deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,21 @@ env ANSIBLE_SKIP_TAGS= ansible-playbook playbooks/name_of_playbook.yml
 Note that `--skip-tags=[]` doesn't work because the skip tags setting in
 `ansible.cfg` takes precedence over command line options.
 
+## Pause before finalizing deploy
+
+If you want to pause the playbook before the new version is switched live,
+there is an optional pause step you can enable using tags. When running normally and skipping setup tasks, run as follows:
+
+```{bash}
+ansible-playbook --tags=all,final-pause playbooks/playbook.yml
+```
+
+When running with setup steps enabled:
+
+```{bash}
+env ANSIBLE_SKIP_TAGS= ansible-playbook --tags=all,final-pause playbooks/playbook.yml
+```
+
 ## Revert last deploy
 
 To revert to previous deploy run call the `revert_deploy` playbook with a `host_group` matching the deploy you want to revert, e.g.:

--- a/roles/finalize_deploy/tasks/main.yml
+++ b/roles/finalize_deploy/tasks/main.yml
@@ -9,6 +9,30 @@
   become: true
   become_user: "{{ deploy_user }}"
   block:
+    - name: Create "next" symlink for any final steps before switching live
+      file:
+        src: "{{ deploy }}"
+        dest: "{{ install_root }}/next"
+        state: link
+      tags:
+        - never
+        - final-pause
+
+    - name: pause before switching live
+      ansible.builtin.pause:
+        prompt: "Do any steps needed before the new version is live, e.g., reindexing. (CTRL-C when done)"
+      tags:
+        - never
+        - final-pause
+
+    - name: Remove "next" symlink
+      file:
+        dest: "{{ install_root }}/next"
+        state: absent
+      tags:
+        - never
+        - final-pause
+
     - name: Check for "current" symlink; if present, save path
       stat:
         path: "{{ install_root }}/current"


### PR DESCRIPTION
this change adds an optional pause just before the newly deployed version is made live; must be enabled by specifying with tags

I successfully used this code to deploy an update to the geniza project that switches it to the solr 9 instance, and used the pause to index content into the new solr collection so that there was no downtime with an empty search on the production site while we indexed after the deploy went live.