### PR TITLE
Simplify how setup tasks are skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,16 +77,13 @@ The playbook will run, noting success and failures. The `-v` flag adjusts verbos
 
 ### Skip setup tasks
 
-By default, initial provisioning and setup tasks are configured to be skipped.  Tasks or groups of tasks should be tagged as `setup`.
+By default, initial provisioning and setup tasks are configured to be skipped.  Tasks or groups of tasks should be tagged with both `setup` and `never`.
 
 To run playbook without skipping setup tasks, override the default skip tag configuration:
 
 ```{bash}
-env ANSIBLE_SKIP_TAGS= ansible-playbook playbooks/name_of_playbook.yml
+ansible-playbook --tags=all,setup playbooks/name_of_playbook.yml
 ```
-
-Note that `--skip-tags=[]` doesn't work because the skip tags setting in
-`ansible.cfg` takes precedence over command line options.
 
 ## Pause before finalizing deploy
 
@@ -100,7 +97,7 @@ ansible-playbook --tags=all,final-pause playbooks/playbook.yml
 When running with setup steps enabled:
 
 ```{bash}
-env ANSIBLE_SKIP_TAGS= ansible-playbook --tags=all,final-pause playbooks/playbook.yml
+ansible-playbook --tags=all,setup,final-pause playbooks/playbook.yml
 ```
 
 ## Revert last deploy

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The playbook will run, noting success and failures. The `-v` flag adjusts verbos
 
 By default, initial provisioning and setup tasks are configured to be skipped.  Tasks or groups of tasks should be tagged with both `setup` and `never`.
 
-To run playbook without skipping setup tasks, override the default skip tag configuration:
+To run playbook without skipping setup tasks, pass the `setup` and `all` tags, so untagged tasks and tasks tagged `setup` run:
 
 ```{bash}
 ansible-playbook --tags=all,setup playbooks/name_of_playbook.yml

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -10,6 +10,3 @@ vault_identity_list=default@bin/lpass_default.sh,geniza@bin/lpass_geniza.sh
 
 [ssh-connection]
 pipelining=true
-
-[tags]
-skip=setup

--- a/roles/build_dependencies/tasks/main.yml
+++ b/roles/build_dependencies/tasks/main.yml
@@ -10,7 +10,9 @@
 
 - name: install configured dependencies
   become: true
-  tags: setup
+  tags:
+    - setup
+    - never
   apt:
     name: "{{ common_dependencies + app_dependencies }}"
     state: present
@@ -20,7 +22,9 @@
 
 - name: configure tmux
   become: true
-  tags: setup
+  tags:
+    - setup
+    - never
   copy:
     src: "tmux.conf"
     dest: "/etc/tmux.conf"

--- a/roles/build_npm/tasks/main.yml
+++ b/roles/build_npm/tasks/main.yml
@@ -10,7 +10,9 @@
 
     - name: "Install nodejs from --channel={{ node_version }}/stable"
       become: true
-      tags: setup
+      tags:
+        - setup
+        - never
       community.general.snap:
         name: node
         classic: true

--- a/roles/build_project_repo/tasks/main.yml
+++ b/roles/build_project_repo/tasks/main.yml
@@ -16,7 +16,9 @@
       when: ansible_distribution == 'Springdale'
 
     - name: Ensure deploy user has access to install root
-      tags: setup
+      tags:
+        - setup
+        - never
       become: true
       file:
         dest: "{{ install_root }}"
@@ -53,7 +55,9 @@
 
     - name: Create the deploy directory (to recursively create parent dirs if necessary)
       become: true
-      tags: setup
+      tags:
+        - setup
+        - never
       become_user: "{{ deploy_user }}"
       file:
         state: directory

--- a/roles/configure_logging/tasks/main.yml
+++ b/roles/configure_logging/tasks/main.yml
@@ -3,7 +3,9 @@
 # Apache to write log files for the Django application.
 ###
 - name: Set up and configure logging
-  tags: setup
+  tags:
+    - setup
+    - never
   become: "{{ 'true' if ansible_distribution != 'Springdale' else 'false' }}"
   block:
     - name: Create logging directory

--- a/roles/configure_media/tasks/main.yml
+++ b/roles/configure_media/tasks/main.yml
@@ -5,14 +5,18 @@
   become: "{{ 'true' if ansible_distribution != 'Springdale' else 'false' }}"
   block:
     - name: Create media root if it does not already exist
-      tags: setup
+      tags:
+        - setup
+        - never
       file:
         path: "{{ media_root }}"
         state: directory
         mode: "u=rwX,g=rwX,o=X"
 
     - name: Make sure media root is owned by apache user and group
-      tags: setup
+      tags:
+        - setup
+        - never
       file:
         path: "{{ media_root }}"
         owner: "{{ apache_user }}"
@@ -22,7 +26,9 @@
       when: ansible_distribution == 'Ubuntu'
 
     - name: if on qa, set acls appropriately so apache can access
-      tags: setup
+      tags:
+        - setup
+        - never
       acl:
         entity: "{{ apache_group }}"
         etype: group
@@ -34,7 +40,9 @@
       when: qa is defined
 
     - name: Give deploy acl rwx over all files in the directory as a fall back
-      tags: setup
+      tags:
+        - setup
+        - never
       acl:
         entity: "{{ deploy_user }}"
         etype: user

--- a/roles/deploy_user/tasks/main.yml
+++ b/roles/deploy_user/tasks/main.yml
@@ -4,7 +4,6 @@
   become: true
   tags:
     - setup
-    - cdhsetup  # ?
     - never
   block:
     - name: Create deploy user group

--- a/roles/deploy_user/tasks/main.yml
+++ b/roles/deploy_user/tasks/main.yml
@@ -4,7 +4,8 @@
   become: true
   tags:
     - setup
-    - cdhsetup
+    - cdhsetup  # ?
+    - never
   block:
     - name: Create deploy user group
       ansible.builtin.group:

--- a/roles/django/tasks/compilemessages.yml
+++ b/roles/django/tasks/compilemessages.yml
@@ -4,7 +4,9 @@
 
 - name: Ensure gnu gettext is installed
   become: true
-  tags: setup
+  tags:
+    - setup
+    - never
   ansible.builtin.apt:
     name: gettext
     state: present

--- a/roles/passenger/tasks/main.yml
+++ b/roles/passenger/tasks/main.yml
@@ -14,40 +14,52 @@
 
     # Passenger repository setup.
     - name: Add Passenger apt key.
-      tags: setup
+      tags:
+        - setup
+        - never
       ansible.builtin.apt_key:
         keyserver: keyserver.ubuntu.com
         id: 561F9B9CAC40B2F7
         state: present
 
     - name: Add apt HTTPS capabilities.
-      tags: setup
+      tags:
+        - setup
+        - never
       ansible.builtin.apt:
         name: apt-transport-https
         state: present
 
     - name: Add Phusion apt repo.
-      tags: setup
+      tags:
+        - setup
+        - never
       ansible.builtin.apt_repository:
         repo: 'deb https://oss-binaries.phusionpassenger.com/apt/passenger {{ ansible_distribution_release }} main'
         state: present
         # ignore_errors: true
 
     - name: Add key for Phusion apt repo
-      tags: setup
+      tags:
+        - setup
+        - never
       ansible.builtin.apt_key:
         keyserver: keyserver.ubuntu.com
         id: 561F9B9CAC40B2F7
 
     - name: Update our repositories
-      tags: setup
+      tags:
+        - setup
+        - never
       become: true
       ansible.builtin.apt:
         update_cache: true
 
     # Nginx and passenger installation.
     - name: Install Nginx and Passenger.
-      tags: setup
+      tags:
+        - setup
+        - never
       become: true
       ansible.builtin.apt:
         name: "{{ nginx_passenger_packages }}"

--- a/roles/postgresql/tasks/create_db.yml
+++ b/roles/postgresql/tasks/create_db.yml
@@ -15,3 +15,4 @@
   changed_when: false
   tags:
     - setup
+    - never

--- a/roles/postgresql/tasks/create_user.yml
+++ b/roles/postgresql/tasks/create_user.yml
@@ -16,3 +16,4 @@
   tags:
     - create_user
     - setup
+    - never

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -4,21 +4,27 @@
 
 - name: Make sure CA certificates are available
   become: true
-  tags: setup
+  tags:
+    - setup
+    - never
   ansible.builtin.apt:
     pkg: ca-certificates
     state: present
 
 - name: Add postgres repository apt-key
   become: true
-  tags: setup
+  tags:
+    - setup
+    - never
   ansible.builtin.apt_key:
     url: "{{ postgres_apt_key_url }}"
     state: present
 
 - name: Add postgres repository
   become: true
-  tags: setup
+  tags:
+    - setup
+    - never
   ansible.builtin.apt_repository:
     repo: "{{ postgres_apt_repository }}"
     update_cache: true
@@ -26,7 +32,9 @@
 
 - name: Install postgres client libraries
   become: true
-  tags: setup
+  tags:
+    - setup
+    - never
   ansible.builtin.apt:
     name: "{{ item }}"
     state: present
@@ -38,7 +46,9 @@
     - postgresql-client-{{ postgres_version }}
 
 - name: Ensure access to postgres server
-  tags: setup
+  tags:
+    - setup
+    - never
   become: true
   ansible.builtin.lineinfile:
     path: "/etc/postgresql/{{ postgres_version }}/main/pg_hba.conf"
@@ -47,7 +57,9 @@
 
 - name: Reload remote postgres server
   become: true
-  tags: setup
+  tags:
+    - setup
+    - never
   ansible.builtin.service:
     name: postgresql
     state: reloaded

--- a/roles/prosody_setup/tasks/main.yml
+++ b/roles/prosody_setup/tasks/main.yml
@@ -2,7 +2,9 @@
 # tasks specific to setting up prosody archive
 
 - name: Ensure HathiTrust pairtree directory exists and has correct permissions
-  tags: setup
+  tags:
+    - setup
+    - never
   ansible.builtin.file:
     path: "{{ hathitrust_pairtree_path }}"
     state: directory
@@ -21,7 +23,9 @@
   when: not marc_pairtree_root.stat.exists
 
 - name: Ensure MARC data dir has correct permissions
-  tags: setup
+  tags:
+    - setup
+    - never
   ansible.builtin.file:
     path: "{{ marc_data_path }}"
     state: directory

--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -6,7 +6,9 @@
 # the vault key is not available.
 
 - name: Load vaulted setup variables if appropriate
-  tags: setup
+  tags:
+    - setup
+    - never
   ansible.builtin.include_vars:
     file: vars/vault.yml
   when: geniza_deploy_only is not defined or geniza_deploy_only == ""

--- a/roles/solr_collection/tasks/main.yml
+++ b/roles/solr_collection/tasks/main.yml
@@ -1,7 +1,9 @@
 ---
 # tasks file for roles/solr_collection
 - name: Create the base directory for Solr configsets
-  tags: setup
+  tags:
+    - setup
+    - never
   file:
     path: "/solr/cdh_solr/"
     state: directory


### PR DESCRIPTION
use `never` to skip setup tasks by default, rather than configuring it as a tag to be skipped by default (which is harder to override)

I haven't run the playbooks with this configuration, but I used the `--list-tasks` option to check and it looks like it's configured properly