### PR TITLE
Update simrisk playbook and vars to deploy to pulcloud

### DIFF
--- a/group_vars/sandbox/simrisk.yml
+++ b/group_vars/sandbox/simrisk.yml
@@ -14,13 +14,15 @@ gitref: '{{ ref | default("main") }}'
 
 # use python 3.9
 python_version: "3.9"
-# for simulatingrisk, don't differentiate qa/prod paths
+# where to install the application code
 install_root: '/srv/www/{{ app_name }}'
 
+
 # configure to run via supervisor
+# runs at a non top-level path when on the sandbox
 supervisor_programs:
   - name: 'simulatingrisk'
-    command: "{{ install_root }}/current/env/bin/solara run --host 0.0.0.0 --port 8765 --root-path /{{ app_name }} {{ install_root }}/current/simulatingrisk/app.py"
+    command: "{{ install_root }}/current/env/bin/solara run --host 0.0.0.0 --port 8765 {% if inventory_hostname in groups['sandbox'] %}--root-path /{{ app_name }}{% endif %} {{ install_root }}/current/simulatingrisk/app.py"
     state: present
     configuration: |
       directory={{ install_root }}/current

--- a/hosts
+++ b/hosts
@@ -74,6 +74,10 @@ prosody_prod
 [sandbox]
 cdh-dev-sandbox1.princeton.edu
 
+# must be configured in ssh config with bastion proxy command
+[simrisk]
+simrisk
+
 ### PUL solr servers
 
 [solr_staging]
@@ -111,6 +115,7 @@ derrida_crawl_qa
 derrida_archive_qa
 prosody_qa
 sandbox
+simrisk
 
 [dev]
 localhost

--- a/playbooks/simulatingrisk_dev.yml
+++ b/playbooks/simulatingrisk_dev.yml
@@ -1,4 +1,4 @@
-- hosts: sandbox
+- hosts: sandbox, simrisk
   vars_files:
     - ../group_vars/sandbox/simrisk.yml
   connection: ssh

--- a/roles/sandbox/tasks/main.yml
+++ b/roles/sandbox/tasks/main.yml
@@ -4,6 +4,7 @@
   tags:
     - setup
     - never
+  when: "'sandbox' in group_names"   # only run this on sandbox hosts
   block:
     - name: Make sure nginx and passenger are configured
       ansible.builtin.include_role:


### PR DESCRIPTION
- add pulcloud simrisk to hosts inventory and to simrisk playbook
- only run sandbox task on sandbox hosts
- configure simulatingrisk to run at app-specific root path on sandbox only

playbook works, and I was able to deploy to both sandbox and simrisk cloud at the same time 🎉 


## questions
- hosts config assumes/requires ssh config is setup for cloud with bastion host; should this be documented anywhere in ansible repo or readme?
- ansible complains that simrisk host == simrisk group; suggestions?