### PR TITLE
Configure steps that should only run once

### DIFF
--- a/group_vars/geniza/vars.yml
+++ b/group_vars/geniza/vars.yml
@@ -123,6 +123,9 @@ solr_configset: geniza
 deploy_contexts:
   - "Python unit tests"
 
+# run cron jobs only on the first machine in the host group
+cronjob_host: "{{ groups['geniza_prod'][0] }}"
+
 # configure scripts to run as cron jobs
 crontab:
   - name: "{{ app_name }} reindex"

--- a/group_vars/geniza/vars.yml
+++ b/group_vars/geniza/vars.yml
@@ -124,7 +124,7 @@ deploy_contexts:
   - "Python unit tests"
 
 # run cron jobs only on the first machine in the host group
-cronjob_host: "{{ groups['geniza_prod'][0] }}"
+cronjob_host: "cdh-geniza1.princeton.edu"
 
 # configure scripts to run as cron jobs
 crontab:

--- a/group_vars/geniza_qa/vars.yml
+++ b/group_vars/geniza_qa/vars.yml
@@ -14,7 +14,7 @@ solr_server: "{{ groups['solr9_staging'][0] }}"
 solr_version: 9
 
 # run cron jobs only on the first machine in the host group
-cronjob_host: "{{ groups['geniza_qa'][0] }}"
+cronjob_host: "cdh-test-geniza1.princeton.edu"
 
 # enable warning banner; configured in geniza local settings
 show_warning_banner: true

--- a/group_vars/geniza_qa/vars.yml
+++ b/group_vars/geniza_qa/vars.yml
@@ -13,6 +13,9 @@ solr_url: "http://lib-solr9-staging.princeton.edu:8983/solr/"
 solr_server: "{{ groups['solr9_staging'][0] }}"
 solr_version: 9
 
+# run cron jobs only on the first machine in the host group
+cronjob_host: "{{ groups['geniza_qa'][0] }}"
+
 # enable warning banner; configured in geniza local settings
 show_warning_banner: true
 # use defaults for test site warning/reminder

--- a/group_vars/shxco_prod/vars.yml
+++ b/group_vars/shxco_prod/vars.yml
@@ -20,7 +20,7 @@ deploy_contexts:
 #    - 'Analyze (python)'
 
 # run cron jobs only on the first machine in the host group
-cronjob_host: "{{ groups['shxco_prod'][0] }}"
+cronjob_host: "cdh-shxco1.princeton.edu"
 
 # configure scripts to run as cron jobs
 crontab:

--- a/group_vars/shxco_prod/vars.yml
+++ b/group_vars/shxco_prod/vars.yml
@@ -19,6 +19,9 @@ deploy_contexts:
 #    - 'Analyze (javascript)'
 #    - 'Analyze (python)'
 
+# run cron jobs only on the first machine in the host group
+cronjob_host: "{{ groups['shxco_prod'][0] }}"
+
 # configure scripts to run as cron jobs
 crontab:
 

--- a/roles/build_project_repo/tasks/main.yml
+++ b/roles/build_project_repo/tasks/main.yml
@@ -43,6 +43,7 @@
     - name: Get the version for the python package/app being deployed
       become: true
       become_user: "{{ deploy_user }}"
+      run_once: true
       shell:
         cmd: "python3 -c 'import {{ python_app }}; print({{ python_app }}.__version__)'"
         chdir: "{{ clone_root}}/{{ repo }}"

--- a/roles/close_deployment/tasks/main.yml
+++ b/roles/close_deployment/tasks/main.yml
@@ -4,6 +4,7 @@
 ###
 
 - name: Close GitHub deployment as a success.
+  run_once: true
   tags:
     - gh_deploy
   uri:

--- a/roles/configure_crontab/tasks/main.yml
+++ b/roles/configure_crontab/tasks/main.yml
@@ -1,4 +1,5 @@
 - name: Configure cron jobs
+  when: inventory_hostname == cronjob_host
   block:
   - name: "Configure crontab — special times"
     cron:

--- a/roles/configure_crontab/tasks/main.yml
+++ b/roles/configure_crontab/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Configure cron jobs
   block:
-  - name: "Configure crontab — special times"
+  - name: "Configure crontab — special times"
     cron:
       name: "{{ item.name }}"
       special_time: "{{ item.special_time }}"

--- a/roles/create_deployment/tasks/main.yml
+++ b/roles/create_deployment/tasks/main.yml
@@ -6,6 +6,7 @@
 - name: Create a GitHub deployment
   tags:
     - gh_deploy
+  run_once: true
   block:
     - name: Check for GitHub token, and fail if not present
       fail:

--- a/roles/django/tasks/media.yml
+++ b/roles/django/tasks/media.yml
@@ -22,7 +22,7 @@
         state: directory
         recurse: true
       # nfs config (owner/group); this fails on bionic
-      when: ansible_distribution_version != "18.04" or "nfs" not in media_root
+      when: "ansible_distribution_version != '18.04' and 'nfs' not in media_root"
 
     - name: Give deploy acl rwx over all files in the directory as a fall back
       become: true

--- a/roles/django/tasks/migrate.yml
+++ b/roles/django/tasks/migrate.yml
@@ -5,6 +5,7 @@
 - name: Run database migrations
   become: true
   become_user: "{{ django_user }}"
+  run_once: true
   community.general.django_manage:
     command: migrate
     app_path: "{{ django_app_path }}"

--- a/roles/postgresql/tasks/backup_db.yml
+++ b/roles/postgresql/tasks/backup_db.yml
@@ -2,6 +2,7 @@
 # back up the database to a location on the app's host (not the db host)
 - name: Backup postgres database
   tags: db_backup
+  run_once: true
   block:
     - name: Check postgres backup path
       become: true

--- a/roles/postgresql/tasks/create_db.yml
+++ b/roles/postgresql/tasks/create_db.yml
@@ -3,6 +3,7 @@
 # https://github.com/pulibrary/princeton_ansible/blob/main/roles/postgresql/tasks/create_db.yml
 
 - name: Ensure postgres database for app exists
+  run_once: true
   community.postgresql.postgresql_db:
     name: "{{ application_db_name }}"
     login_host: "{{ postgres_host }}"

--- a/roles/postgresql/tasks/create_user.yml
+++ b/roles/postgresql/tasks/create_user.yml
@@ -3,6 +3,7 @@
 # https://github.com/pulibrary/princeton_ansible/blob/main/roles/postgresql/tasks/create_users.yml
 
 - name: Ensure postgres user account for app exists
+  run_once: true
   community.postgresql.postgresql_user:
     name: "{{ application_dbuser_name }}"
     login_host: "{{ postgres_host }}"

--- a/roles/solr_collection/tasks/main.yml
+++ b/roles/solr_collection/tasks/main.yml
@@ -4,6 +4,7 @@
   tags:
     - setup
     - never
+  run_once: true
   file:
     path: "/solr/cdh_solr/"
     state: directory
@@ -14,6 +15,7 @@
   delegate_to: "{{ solr_server }}" # lib-solr-staging1.princeton.edu  # solr_staging
 
 - name: Update and configure Solr configset
+  run_once: true
   block:
     - name: Copy project Solr configset files for upload to zookeeper
       # rsync configset from deployed version on remote host to solr server


### PR DESCRIPTION
- add `run_once` to steps that should only be run once even if deploying to multiple hosts
- revise cron role so cron jobs will only be configured on a specified server