### PR TITLE
geotaste playbook revisions

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -53,7 +53,7 @@ short_hash: '{{ repo_info.after[0:6] }}'
 # Path of the deploy directory. Generated from vars above and build_project_repo
 deploy: '{{ install_root }}/{{ version }}-{{ short_hash }}'
 # python app version. Generated in build_project_repo
-version: '{{ python_app_version.stdout }}'
+version: '{{ python_app_version }}'
 # logging directory
 logging_dir: '{{ install_root }}/logs'
 # logging file

--- a/roles/build_project_repo/tasks/main.yml
+++ b/roles/build_project_repo/tasks/main.yml
@@ -30,7 +30,7 @@
       # (i.e. on PUL vms, where deploy user is different than remote user)
       when: deploy_user is defined and ansible_distribution != 'Springdale'
 
-    - name: Clone project repository and set to the correct version
+    - name: Clone project repository and checkout the correct git reference
       become: true
       become_user: "{{ deploy_user }}"
       git:
@@ -40,47 +40,10 @@
       # register repo_info for group_vars
       register: repo_info
 
-    - name: Check if version number file exists
-      stat:
-        path: "{{ clone_root}}/{{ repo }}/version.py"
-      register: py_version_file_result
-
-    - name: Get the version number from version.py filename
-      become: true
-      become_user: "{{ deploy_user }}"
-      shell:
-        cmd: "python3 -c 'import version; print(version.__version__)'"
-        chdir: "{{ clone_root}}/{{ repo }}"
-      register: py_version_file
-      tags:
-        - python
+    - name: Determine version of python app being deployed
+      ansible.builtin.import_tasks: python_app_version.yml
       when:
-        - py_version_file_result.stat.exists
-
-    - name: Get the version number from the python package/app being deployed
-      become: true
-      become_user: "{{ deploy_user }}"
-      shell:
-        cmd: "python3 -c 'import {{ python_app }}; print({{ python_app }}.__version__)'"
-        chdir: "{{ clone_root}}/{{ repo }}"
-      register: py_version_app
-      tags:
-        - python
-      when: 
-        - not py_version_file_result.stat.exists
         - python_app is defined
-
-    - name: storing version number from version.py
-      set_fact:
-        python_app_version: "{{ py_version_file }}"
-      when: 
-        - py_version_file.stdout is defined
-    
-    - name: storing version number from python package import
-      set_fact:
-        python_app_version: "{{ py_version_app }}"
-      when: 
-        - py_version_app.stdout is defined
 
     - name: Create the deploy directory (to recursively create parent dirs if necessary)
       become: true

--- a/roles/build_project_repo/tasks/python_app_version.yml
+++ b/roles/build_project_repo/tasks/python_app_version.yml
@@ -1,0 +1,41 @@
+# Determine the version of the python app being deployed
+- name: Determine python app version
+  tags:
+    - python
+  block:
+    - name: Check if project has a version.py file
+      stat:
+        path: "{{ clone_root}}/{{ repo }}/{{ python_app }}/version.py"
+      register: python_version_file
+
+    - name: Get the version for the python package/app being deployed (app.version)
+      become: true
+      become_user: "{{ deploy_user }}"
+      shell:
+        cmd: "python3 -c 'from {{ python_app }} import version; print(version.__version__)'"
+        chdir: "{{ clone_root}}/{{ repo }}"
+      register: python_app_version
+      # when skipped, registers a variable with info with skip / conditional info
+      when:
+        - python_version_file.stat.exists
+
+    - name: debug python app version
+      ansible.builtin.debug:
+        msg: python_app_version = {{ python_app_version}}
+
+    - name: Get the version for the python package/app being deployed (app.__version__)
+      become: true
+      become_user: "{{ deploy_user }}"
+      shell:
+        cmd: "python3 -c 'import {{ python_app }}; print({{ python_app }}.__version__)'"
+        chdir: "{{ clone_root}}/{{ repo }}"
+      register: python_app_version
+      tags:
+        - python
+      when:
+        - not python_version_file.stat.exists
+        # alternately, could check if python_app_version.skipped is True
+
+    - name: Set python app version as a fact
+      set_fact:
+        python_app_version: "{{ python_app_version.stdout }}"

--- a/roles/finalize_deploy/tasks/main.yml
+++ b/roles/finalize_deploy/tasks/main.yml
@@ -63,26 +63,6 @@
         path: "{{ install_root }}/previous"
       register: previous
 
-    - name: Check if /var/www exists
-      stat:
-        path: "/var/www"
-      register: var_www_exists
-
-    - name: Create /var/www if necessary on Ubuntu (root)
-      become_user: root
-      shell:
-        cmd: "mkdir -p /var/www"
-      when: 
-        - not var_www_exists.stat.exists
-        - ansible_distribution != 'Springdale'
-
-    - name: Create /var/www if necessary on Springdale (deploy user)
-      shell:
-        cmd: "mkdir -p /var/www"
-      when: 
-        - not var_www_exists.stat.exists
-        - ansible_distribution == 'Springdale'
-    
     # On Ubuntu we need to do this with an account that can access both /srv
     # and /var, so we need to be root
     - name: Update /var/www/ symlink to make the new version live
@@ -93,7 +73,8 @@
         state: link
       notify:
         - Restart nginx
-      when: ansible_distribution != 'Springdale'
+      when:
+        - "'passenger' in ansible_role_names"
 
     # On Springdale we can do this as deploy_user
     - name: Update /var/www/ symlink to make the new version live


### PR DESCRIPTION
- only set /var/www app symlink and notify restart nginx when passenger is included in playbook roles
- move python app version logic into a separate task file + simplify logic slightly


I've run this successfully on the simrisk playbook. We should test a few others before we merge to main to make sure it doesn't break anything.