### PR TITLE
Update staging variables for new jammy staging solr server

### DIFF
--- a/group_vars/geniza_staging/vars.yml
+++ b/group_vars/geniza_staging/vars.yml
@@ -8,6 +8,7 @@ application_url: "test-geniza.cdh.princeton.edu"
 passenger_server_name: "{{ application_url }}"
 
 # solr settings
+# geniza is using solr 9, so must override default staging solr 8 config
 zk_host: "lib-zk-staging4:2181,lib-zk-staging5:2181,lib-zk-staging6:2181/solr9"
 solr_url: "http://lib-solr9-staging.princeton.edu:8983/solr/"
 solr_server: "{{ groups['solr9_staging'][0] }}"

--- a/group_vars/prosody_staging/vars.yml
+++ b/group_vars/prosody_staging/vars.yml
@@ -11,11 +11,5 @@ application_url: "test-ppa.cdh.princeton.edu"
 # passenger settings
 passenger_server_name: "{{ application_url }}"
 
-# solr settings
-# NOTE: should be moved somewhere common; zk is unique but solr vars used for old deploys
-zk_host: "lib-zk-staging1:2181,lib-zk-staging2:2181,lib-zk-staging3:2181/solr8"
-solr_url: "http://lib-solr8-staging.princeton.edu:8983/solr/"
-solr_server: "{{ groups['solr_staging'][0] }}"
-
 # source host when replicating data/media (from ansible host inventory file)
 replication_source_host: prosody_production

--- a/group_vars/shxco_staging/vars.yml
+++ b/group_vars/shxco_staging/vars.yml
@@ -6,12 +6,6 @@
 # email prefix for staging error emails
 email_prefix: '[S&co STAGING] '
 
-# solr settings
-# NOTE: should be moved somewhere common; zk is unique but solr vars used for old deploys
-zk_host: "lib-zk-staging1:2181,lib-zk-staging2:2181,lib-zk-staging3:2181/solr8"
-solr_url: "http://lib-solr8-staging.princeton.edu:8983/solr/"
-solr_server: "{{ groups['solr_staging'][0] }}"
-
 # override passenger server name with staging hostname
 application_url: "test-shakespeareandco.cdh.princeton.edu"
 

--- a/group_vars/staging/vars.yml
+++ b/group_vars/staging/vars.yml
@@ -4,9 +4,15 @@
 ---
 # configure staging to deploy develop branch by default
 gitref: '{{ ref | default("develop") }}'
-# solr configurations for a local Solr instance
-solr_url: http://127.0.0.1:8983/solr/
+
+# solr settings
+# using solr staging on jammy vm
+# - api access
+solr_url: "http://lib-solr8d-staging.princeton.edu:8983/solr/"
 solr_admin_url: '{{ solr_url }}admin/cores'
+zk_host: "lib-zk-staging1d:2181,lib-zk-staging2d:2181,lib-zk-staging3d:2181/solr8"
+# - server name for deploy setup
+solr_server: "{{ groups['solr_staging'][0] }}"
 
 # allow any deploy contexts (no ci/coverage checks before deploying)
 deploy_contexts: []

--- a/hosts
+++ b/hosts
@@ -92,7 +92,7 @@ gcp_geotaste
 ### PUL solr servers
 
 [solr_staging]
-lib-solr-staging4.princeton.edu
+lib-solr-staging4d.princeton.edu
 [solr_production]
 lib-solr-prod4.princeton.edu
 


### PR DESCRIPTION
fixes #190 

- consolidates common solr 8 staging settings in one place
- update configuration to use new solr 8 jammy staging server 

successfully deployed shxco and prosody to staging, created new solr collections, and am indexing the content into the new collections