### PR TITLE
Add tasks and replicate playbook steps for solr collection replication 

### DIFF
--- a/playbooks/replicate.yml
+++ b/playbooks/replicate.yml
@@ -214,6 +214,6 @@
         become: true
         become_user: "{{ deploy_user }}"
         # run as conan, since we already have keys setup for conan ssh from staging to production
-        # because this is stored on nfs we can't use -avz (permissions/chown)
-        ansible.builtin.command: /usr/bin/rsync -rltDz "{{ source_user }}@{{ source_hostname }}:{{ hathitrust_pairtree_path }}" "{{ hathitrust_pairtree_path }}" -e "ssh -o StrictHostKeyChecking=no"
+        # use --delete to remove any files in staging that don't exist in production
+        ansible.builtin.command: /usr/bin/rsync -avz --delete "{{ source_user }}@{{ source_hostname }}:{{ hathitrust_pairtree_path }}" "{{ hathitrust_pairtree_path }}" -e "ssh -o StrictHostKeyChecking=no"
         when: "'prosody' in group_names"   # this is specific to ppa

--- a/playbooks/replicate.yml
+++ b/playbooks/replicate.yml
@@ -47,6 +47,15 @@
       become_user: "{{ deploy_user }}"
       when: media_files.matched|int != 0
 
+    - name: Request a solr collection backup, if application uses solr
+      run_once: true
+      tags:
+        - solr_backup
+      include_role:
+        name: solr_collection
+        tasks_from: backup_solr_collection.yml
+      when: solr_collection is defined
+
 # destination host tasks
 - name: Restore database and media backups on target host
   # hosts: dev
@@ -63,6 +72,8 @@
      # NOTE: override db_backup_filename if db names differ between qa/prod
   tasks:
       - name: Get replication source hostname
+        tags:
+          - always
         set_fact:
           source_hostname: "{{ item }}"
         with_inventory_hostnames:
@@ -82,6 +93,15 @@
         ansible.builtin.command: /usr/bin/rsync -avz "{{ source_user }}@{{ source_hostname }}:{{ db_backup_path }}" "{{ dest_backup_path }}" -e "ssh -o StrictHostKeyChecking=no"
         become: true
         become_user: "{{ deploy_user }}"
+
+      - name: Restore solr collection from backup, if application uses solr
+        run_once: true
+        tags:
+          - solr_backup  # must be tagged here AND in the included task
+        include_role:
+          name: solr_collection
+          tasks_from: restore_solr_collection.yml
+        when: solr_collection is defined
 
       - name: Check for media tar file on source
         stat:
@@ -187,3 +207,4 @@
           login_password: '{{ application_dbuser_password }}'
           query: "UPDATE django_site SET domain = '{{ application_url }}', name = '{{ application_url }}' WHERE id = 1;"
         when: "'prod' not in group_names"   # never run this on production
+

--- a/playbooks/replicate.yml
+++ b/playbooks/replicate.yml
@@ -208,3 +208,12 @@
           query: "UPDATE django_site SET domain = '{{ application_url }}', name = '{{ application_url }}' WHERE id = 1;"
         when: "'prod' not in group_names"   # never run this on production
 
+      - name: rsync hathitrust pairtree data from production to staging (PPA only)
+        tags:
+          - ppa_pairtree
+        become: true
+        become_user: "{{ deploy_user }}"
+        # run as conan, since we already have keys setup for conan ssh from staging to production
+        # because this is stored on nfs we can't use -avz (permissions/chown)
+        ansible.builtin.command: /usr/bin/rsync -rltDz "{{ source_user }}@{{ source_hostname }}:{{ hathitrust_pairtree_path }}" "{{ hathitrust_pairtree_path }}" -e "ssh -o StrictHostKeyChecking=no"
+        when: "'prosody' in group_names"   # this is specific to ppa

--- a/roles/solr_collection/defaults/main.yml
+++ b/roles/solr_collection/defaults/main.yml
@@ -1,5 +1,19 @@
 ---
+# default solr version
+# used to determine whether to run shard per node tasks (not in solr 9)
+solr_version: 8
+
 # defaults file for roles/solr_collection
 num_shards: 1
 replication_factor: 3
 shards_per_node: 1
+
+# PUL backup paths use YYYYMMDD format
+solr_backup_date: "{{'%Y%m%d' | strftime(ansible_date_time.epoch) }}"
+# NOTE: backup path for current date is created for us
+# by an existing PUL solr backup cron job.
+# However, they are likely not yet be present for solr9
+solr_backup_location: "/mnt/solr_backup/solr{{ solr_version}}/production/{{ solr_backup_date }}/"
+solr_backup_filename: "{{ solr_collection }}-{{solr_backup_date}}.bk"
+solr_backup_request_id:  "{{solr_collection }}-{{ansible_date_time.iso8601 }}"
+solr_delete_request_id:  "rm-{{solr_collection }}-{{ansible_date_time.iso8601 }}"

--- a/roles/solr_collection/tasks/backup_solr_collection.yml
+++ b/roles/solr_collection/tasks/backup_solr_collection.yml
@@ -35,3 +35,8 @@
       ansible.builtin.debug:
         msg: "Backup status not found: {{ status_response.json['exception']['msg'] }}"
       when: status_response.json["status"]["state"] == "notfound"
+
+    - name: Report status request timeout
+      ansible.builtin.debug:
+        msg: "Status request timed out; last status was: {{ status_response.json['status']['state'] }}"
+      when: status_response.json["status"]["state"] not in in ["completed", "failed", "notfound"]

--- a/roles/solr_collection/tasks/backup_solr_collection.yml
+++ b/roles/solr_collection/tasks/backup_solr_collection.yml
@@ -17,26 +17,18 @@
       uri:
         url: "{{ solr_url }}admin/collections?action=REQUESTSTATUS&requestid={{ solr_backup_request_id }}"
       register: status_response
-      until: status_response.json["status"]["state"] in ["completed", "failed", "notfound"]
-      retries: 10
-      delay: 5
+      # known states: running, completed, failed, notfound
+      until: status_response.json["status"]["state"] != "running"
+      retries: 15
+      delay: 10
 
-    - name: Report succcess
+    - name: Report backup success
       ansible.builtin.debug:
         msg: "Successfully backed up {{ solr_collection }} to {{ solr_backup_location }}{{ solr_backup_filename }}"
       when: status_response.json["status"]["state"] == "completed"
 
-    - name: Report error
+    - name: Report backup error
       ansible.builtin.debug:
-        msg: "Backup failed: {{ status_response.json['exception']['msg'] }}"
-      when: status_response.json["status"]["state"] == "failed"
+        msg: "Backup {{ status_response.json['status']['state'] }}: {{ status_response.json['exception']['msg'] }}"
+      when: status_response.json["status"]["state"] != "completed"
 
-    - name: Report status not found
-      ansible.builtin.debug:
-        msg: "Backup status not found: {{ status_response.json['exception']['msg'] }}"
-      when: status_response.json["status"]["state"] == "notfound"
-
-    - name: Report status request timeout
-      ansible.builtin.debug:
-        msg: "Status request timed out; last status was: {{ status_response.json['status']['state'] }}"
-      when: status_response.json["status"]["state"] not in in ["completed", "failed", "notfound"]

--- a/roles/solr_collection/tasks/backup_solr_collection.yml
+++ b/roles/solr_collection/tasks/backup_solr_collection.yml
@@ -1,0 +1,37 @@
+---
+# back up a solr collection to a location on solr server
+- name: Backup solr collection
+  run_once: true
+  tags:
+    - solr_backup
+  block:
+    - name: Request Solr collection backup
+      uri:
+        url: "{{ solr_url }}admin/collections?action=BACKUP&collection={{ solr_collection }}&name={{ solr_backup_filename }}&location={{ solr_backup_location }}&async={{ solr_backup_request_id }}"
+      register: backup_response
+      # NOTE: using async request, since backup for larger collections
+      # maky take some time
+
+      # use the async request id to check status; wait until task completes
+    - name: Request backup status
+      uri:
+        url: "{{ solr_url }}admin/collections?action=REQUESTSTATUS&requestid={{ solr_backup_request_id }}"
+      register: status_response
+      until: status_response.json["status"]["state"] in ["completed", "failed", "notfound"]
+      retries: 10
+      delay: 5
+
+    - name: Report succcess
+      ansible.builtin.debug:
+        msg: "Successfully backed up {{ solr_collection }} to {{ solr_backup_location }}{{ solr_backup_filename }}"
+      when: status_response.json["status"]["state"] == "completed"
+
+    - name: Report error
+      ansible.builtin.debug:
+        msg: "Backup failed: {{ status_response.json['exception']['msg'] }}"
+      when: status_response.json["status"]["state"] == "failed"
+
+    - name: Report status not found
+      ansible.builtin.debug:
+        msg: "Backup status not found: {{ status_response.json['exception']['msg'] }}"
+      when: status_response.json["status"]["state"] == "notfound"

--- a/roles/solr_collection/tasks/restore_solr_collection.yml
+++ b/roles/solr_collection/tasks/restore_solr_collection.yml
@@ -1,0 +1,66 @@
+---
+# Restore a solr collection from a solr backup available on the server
+- name: Restore solr collection
+  run_once: true
+  tags:
+    - solr_backup
+  block:
+    - name: Delete existing Solr collection
+      uri:
+        url: "{{ solr_url }}admin/collections?action=DELETE&name={{ solr_collection }}&async={{ solr_delete_request_id }}"
+      when: "'prod' not in group_names"   # never run this on production
+
+     # use the async request id to check status; wait until task completes
+    - name: Request status for delete
+      uri:
+        url: "{{ solr_url }}admin/collections?action=REQUESTSTATUS&requestid={{ solr_delete_request_id }}"
+      register: status_response
+      until: status_response.json["status"]["state"] in ["completed", "failed", "notfound"]
+      retries: 5
+      delay: 10
+
+    - name: Report succcess (delete)
+      ansible.builtin.debug:
+        msg: "Deletion completed for solr collection {{ solr_collection }}"
+      when: status_response.json["status"]["state"] == "completed"
+
+    - name: Report error (delete)
+      ansible.builtin.debug:
+        msg: "Delete failed: {{ status_response.json['exception']['msg'] }}"
+      when: status_response.json["status"]["state"] == "failed"
+
+    - name: Report status not found (delete)
+      ansible.builtin.debug:
+        msg: "Restore status not found: {{ status_response.json['exception']['msg'] }}"
+      when: status_response.json["status"]["state"] == "notfound"
+
+    - name: Restore Solr collection from backup on disk
+      uri:
+        url: "{{ solr_url }}admin/collections?action=RESTORE&collection={{ solr_collection }}&collection.configName={{ solr_configset }}&name={{ solr_backup_filename }}&location={{ solr_backup_location }}&async={{ solr_backup_request_id }}"
+      register: restore_response
+      # NOTE: using async request, since restore for larger collections
+      # maky take some time
+
+      # use the async request id to check status; wait until task completes
+    - name: Request status for restore
+      uri:
+        url: "{{ solr_url }}admin/collections?action=REQUESTSTATUS&requestid={{ solr_backup_request_id }}"
+      register: status_response
+      until: status_response.json["status"]["state"] in ["completed", "failed", "notfound"]
+      retries: 20
+      delay: 10   # restore may take longer for large collections
+
+    - name: Report succcess (restore)
+      ansible.builtin.debug:
+        msg: "Successfully restored {{ solr_collection }} from {{ solr_backup_location }}{{ solr_backup_filename }}"
+      when: status_response.json["status"]["state"] == "completed"
+
+    - name: Report error (restore)
+      ansible.builtin.debug:
+        msg: "Restore failed: {{ status_response.json['exception']['msg'] }}"
+      when: status_response.json["status"]["state"] == "failed"
+
+    - name: Report status not found (restore)
+      ansible.builtin.debug:
+        msg: "Restore status not found: {{ status_response.json['exception']['msg'] }}"
+      when: status_response.json["status"]["state"] == "notfound"

--- a/roles/solr_collection/tasks/restore_solr_collection.yml
+++ b/roles/solr_collection/tasks/restore_solr_collection.yml
@@ -34,6 +34,11 @@
         msg: "Restore status not found: {{ status_response.json['exception']['msg'] }}"
       when: status_response.json["status"]["state"] == "notfound"
 
+    - name: Report status report timeout
+      ansible.builtin.debug:
+        msg: "Status request timed out; last status was: {{ status_response.json['status']['state'] }}"
+      when: status_response.json["status"]["state"] not in ["completed", "failed", "notfound"]
+
     - name: Restore Solr collection from backup on disk
       uri:
         url: "{{ solr_url }}admin/collections?action=RESTORE&collection={{ solr_collection }}&collection.configName={{ solr_configset }}&name={{ solr_backup_filename }}&location={{ solr_backup_location }}&async={{ solr_backup_request_id }}"
@@ -64,3 +69,9 @@
       ansible.builtin.debug:
         msg: "Restore status not found: {{ status_response.json['exception']['msg'] }}"
       when: status_response.json["status"]["state"] == "notfound"
+
+    - name: Report status report timeout
+      ansible.builtin.debug:
+        msg: "Status request timed out; last status was: {{ status_response.json['status']['state'] }}"
+      when: status_response.json["status"]["state"] not in ["completed", "failed", "notfound"]
+

--- a/roles/solr_collection/tasks/restore_solr_collection.yml
+++ b/roles/solr_collection/tasks/restore_solr_collection.yml
@@ -15,29 +15,19 @@
       uri:
         url: "{{ solr_url }}admin/collections?action=REQUESTSTATUS&requestid={{ solr_delete_request_id }}"
       register: status_response
-      until: status_response.json["status"]["state"] in ["completed", "failed", "notfound"]
+      until: status_response.json["status"]["state"] != "running"
       retries: 5
       delay: 10
 
-    - name: Report succcess (delete)
+    - name: Report success (delete)
       ansible.builtin.debug:
         msg: "Deletion completed for solr collection {{ solr_collection }}"
       when: status_response.json["status"]["state"] == "completed"
 
     - name: Report error (delete)
       ansible.builtin.debug:
-        msg: "Delete failed: {{ status_response.json['exception']['msg'] }}"
-      when: status_response.json["status"]["state"] == "failed"
-
-    - name: Report status not found (delete)
-      ansible.builtin.debug:
-        msg: "Restore status not found: {{ status_response.json['exception']['msg'] }}"
-      when: status_response.json["status"]["state"] == "notfound"
-
-    - name: Report status report timeout
-      ansible.builtin.debug:
-        msg: "Status request timed out; last status was: {{ status_response.json['status']['state'] }}"
-      when: status_response.json["status"]["state"] not in ["completed", "failed", "notfound"]
+        msg: "Deletion {{ status_response.json['status']['state'] }}: {{ status_response.json['exception']['msg'] }}"
+      when: status_response.json["status"]["state"] != "completed"
 
     - name: Restore Solr collection from backup on disk
       uri:
@@ -51,7 +41,7 @@
       uri:
         url: "{{ solr_url }}admin/collections?action=REQUESTSTATUS&requestid={{ solr_backup_request_id }}"
       register: status_response
-      until: status_response.json["status"]["state"] in ["completed", "failed", "notfound"]
+      until: status_response.json["status"]["state"] != "running"
       retries: 20
       delay: 10   # restore may take longer for large collections
 
@@ -62,16 +52,5 @@
 
     - name: Report error (restore)
       ansible.builtin.debug:
-        msg: "Restore failed: {{ status_response.json['exception']['msg'] }}"
-      when: status_response.json["status"]["state"] == "failed"
-
-    - name: Report status not found (restore)
-      ansible.builtin.debug:
-        msg: "Restore status not found: {{ status_response.json['exception']['msg'] }}"
-      when: status_response.json["status"]["state"] == "notfound"
-
-    - name: Report status report timeout
-      ansible.builtin.debug:
-        msg: "Status request timed out; last status was: {{ status_response.json['status']['state'] }}"
-      when: status_response.json["status"]["state"] not in ["completed", "failed", "notfound"]
-
+        msg: "Restore {{ status_response.json['status']['state'] }}: {{ status_response.json['exception']['msg'] }}"
+      when: status_response.json["status"]["state"] != "completed"

--- a/roles/solr_collection/vars/main.yml
+++ b/roles/solr_collection/vars/main.yml
@@ -1,6 +1,3 @@
 ---
 # vars file for roles/solr
 
-# default solr version
-# used to determine whether to run shard per node tasks (not in solr 9)
-solr_version: 8


### PR DESCRIPTION
addresses https://github.com/Princeton-CDH/ppa-django/issues/509

- new tasks in solr_collection role to backup and restore collection
- update replicate playbook to use the new tasks
- add prosody-specific replicate step

This playbook has been used successfully to replicate prosody production to staging.

Open to ideas for better ways to handle app-specific replicate steps. We already have a prosody_setup role, so maybe the task should live there and be included here.