### PR TITLE
Updates for ansible-tower

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,7 +6,7 @@ host_key_checking=false
 roles_path=roles
 filter_plugins=filter_plugins
 interpreter_python=/usr/bin/python3
-vault_identity_list=default@bin/lpass_default.sh,geniza@bin/lpass_geniza.sh
+#vault_identity_list=default@bin/lpass_default.sh,geniza@bin/lpass_geniza.sh
 
 [ssh-connection]
 pipelining=true


### PR DESCRIPTION
- disable lastpass config vault identity list in ansible.cfg (tower chokes when loading because `lpass` is not installed)