### PR TITLE
Would removing the scripts make Tower happy?

### DIFF
--- a/bin/lpass_default.sh
+++ b/bin/lpass_default.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# use lastpass cli to get the default cdh-ansible vault password
-
-lpass show --password Ansible_Vault/cdh-ansible

--- a/bin/lpass_geniza.sh
+++ b/bin/lpass_geniza.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# use lastpass cli to get the cdh-ansible password for geniza vault files
-
-lpass show --password Ansible_Vault/cdh-ansible_geniza


### PR DESCRIPTION
Inventory sync from this repo to Tower fails with an error about vault passwords not being found. We wondered if the two scripts are somehow making this happen. 