### PR TITLE
Get NFS idmapd working with ansible

### DIFF
--- a/inventory/group_vars/all/vars.yml
+++ b/inventory/group_vars/all/vars.yml
@@ -128,6 +128,7 @@ media_backup_path: "{{ backup_dir }}{{ media_backup_filename}}"
 nfs_server: "128.112.204.89"
 nfs_host_server: "lib-fs-prod.princeton.edu"
 nfs_enabled: true   # enable nfs by default; opt-out where not needed
+nfs_domain: "princeton.edu"
 
 ## tigerdata
 # NOTE: disabled by default; must opt in by host group; requires firewall access

--- a/roles/setup/handlers/main.yml
+++ b/roles/setup/handlers/main.yml
@@ -1,5 +1,14 @@
 ---
+
+# both nfs-server and nfs-idmapd should be unmasked, enabled, and running
+# (order of these may matter; if it does we should split into a task)
 - name: restart idmapd
-  ansible.builtin.service:
-    name: nfs-idmapd
+  become: true
+  ansible.builtin.systemd_service:
+    name: "{{ item }}"
     state: restarted
+    masked: false
+    enabled: true
+  with_items:
+    - nfs-server
+    - nfs-idmapd

--- a/roles/setup/tasks/nfs.yml
+++ b/roles/setup/tasks/nfs.yml
@@ -10,8 +10,9 @@
   ansible.builtin.lineinfile:
     path: /etc/idmapd.conf
     insertbefore: '# Domain = localdomain'
-    line: "Domain = {{ nfs_host_server }}"
+    line: "Domain = {{ nfs_domain }}"
     state: present
+  notify: restart idmapd
 
 - name: nfsserver | enable id_mapping
   become: true
@@ -24,18 +25,6 @@
     regexp: '^NEED_IDMAPD='
     line: NEED_IDMAPD=yes
   notify: restart idmapd
-
-- name: nfsserver | add fqdn for idmapping
-  become: true
-  tags:
-    - setup
-    - nfs
-    - never
-  ansible.builtin.lineinfile:
-    path: /etc/idmapd.conf
-    insertbefore: '# Domain = localdomain'
-    line: "Domain = {{ nfs_host_server }}"
-    state: present
 
 - name: Ensure the presence of cdh nfs mount
   become: true


### PR DESCRIPTION
- Set nfs domain to princeton.edu 
- revise nfs-idmapd restart handler (unmask, enable, and restart both nfs-server and nfs-imdapd)

I think the domain in the idmapd.conf was the key piece we had wrong. I kept poking at this on other serves and would get it working manually (often working quickly because something was broken), but was never sure which step was the key. This time I got it manually working on cdh-web3 and then by trial and error got ansible to do the same thing on cdh-web4.