### PR TITLE
Move tigerdata nfs mount point to new host and port

### DIFF
--- a/inventory/group_vars/all/vars.yml
+++ b/inventory/group_vars/all/vars.yml
@@ -133,7 +133,8 @@ nfs_domain: "princeton.edu"
 ## tigerdata
 # NOTE: disabled by default; must opt in by host group; requires firewall access
 tigerdata_enabled: false
-tigerdata_nfs_server: "td-mf-cl1"
+tigerdata_nfs_server: "td-mf-cl2.princeton.edu"
+tigerdata_mount_port: 9007
 tigerdata_cdh_group: "cdh"
 tigerdata_cdh_gid: 30369
 tigerdata_mount_dir: /mnt/tigerdata/cdh

--- a/roles/setup/tasks/tigerdata_nfs.yml
+++ b/roles/setup/tasks/tigerdata_nfs.yml
@@ -35,4 +35,4 @@
     path: "{{ tigerdata_mount_dir }}"
     state: mounted
     fstype: nfs
-    opts: nfsvers=3,mountport=9001,port=9001,nolock,proto=tcp
+    opts: "nfsvers=3,mountport={{ tigerdata_mount_port }},port={{ tigerdata_mount_port }},nolock,proto=tcp"


### PR DESCRIPTION
The TigerData team set up a separate host and port for us to try in hopes that it will isolate our NFS mount point from the errors elsewhere in the system that have caused timeouts on our mount point previously. 