### PR TITLE
Configure nfs idmap so it works for BOTH staging and production

### DIFF
--- a/inventory/group_vars/all/vars.yml
+++ b/inventory/group_vars/all/vars.yml
@@ -128,7 +128,8 @@ media_backup_path: "{{ backup_dir }}{{ media_backup_filename}}"
 nfs_server: "128.112.204.89"
 nfs_host_server: "lib-fs-prod.princeton.edu"
 nfs_enabled: true   # enable nfs by default; opt-out where not needed
-nfs_domain: "{{ nfs_host_server }}"
+# in production, idmap seems to be set to princeton.edu rather than full host server name
+nfs_domain: "princeton.edu"
 
 ## tigerdata
 # NOTE: disabled by default; must opt in by host group; requires firewall access

--- a/inventory/group_vars/staging/vars.yml
+++ b/inventory/group_vars/staging/vars.yml
@@ -25,6 +25,8 @@ application_dbuser_role_attr_flags: "CREATEDB"
 # nfs staging server
 nfs_server: "128.112.203.82"
 nfs_host_server: "lib-fs-staging.princeton.edu"
+# in staging, the host domain should be set to host server for idmap to work
+nfs_domain: "{{ nfs_host_server }}"
 
 # turn on test banner for sites that support it
 django_test_warning: true


### PR DESCRIPTION
My comments on #185 were partially wrong - the configuration I had before _was_ correct for production.  I'm not sure why staging and production NFS servers behave differently in terms of domain, but this configuration works for both staging and production.

On a production server:
```{bash}
$ sudo nfsidmap -l
4 .id_resolver keys found:
  uid:www-data@princeton.edu
  user:33
  gid:conan@princeton.edu
  uid:conan@princeton.edu
```
  
On a staging server:
```sh
$ sudo nfsidmap -l
3 .id_resolver keys found:
  uid:www-data@lib-fs-staging.princeton.edu
  gid:conan@lib-fs-staging.princeton.edu
  uid:conan@lib-fs-staging.princeton.edu
```
