### PR TITLE
Updated logic for handling Prodigy environment settings

### DIFF
--- a/inventory/group_vars/prodigy/vars.yml
+++ b/inventory/group_vars/prodigy/vars.yml
@@ -42,7 +42,14 @@ prodigy_options: "{{ prodigy_recipe }} {{ prodigy_dataset }} {{ prodigy_datafile
 # additional prodigy configurations to include in prodigy.json file
 # values here takes precedence over the defaults in the role
 prodigy_config_extra_options:
-prodigy_logging: basic
+# For setting shared and local Prodigy environment variables
+prodigy_common_envs: 
+  PRODIGY_CONFIG: "{{ install_root }}/prodigy.json"
+  PRODIGY_DEPLOYED_URL: "{{ application_url }}"
+  PRODIGY_LOGGING: "basic"
+prodigy_local_envs:
+#  PRODIGY_ALLOWED_SESSIONS: "{{ vault_prodigy_sessions }}"
+prodigy_envs: "{{ prodigy_common_envs | ansible.builtin.combine(prodigy_local_envs)}}"
 
 # configure prodigy to run via supervisor
 supervisor_programs:
@@ -51,7 +58,7 @@ supervisor_programs:
     state: present
     configuration: |
       directory={{ install_root }}
-      environment=PRODIGY_CONFIG="{{ install_root }}/prodigy.json",PRODIGY_DEPLOYED_URL="{{ application_url }}",PRODIGY_LOGGING="{{ prodigy_logging }}"
+      environment={% for name, value in prodigy_envs.items() %}{{ name }}="{{ value }}",{% endfor %}
       autostart=true
       autorestart=true
       startretries=1

--- a/inventory/group_vars/prodigy_staging/vars.yml
+++ b/inventory/group_vars/prodigy_staging/vars.yml
@@ -1,3 +1,5 @@
 ---
 application_url: https://test-prodigy.cdh.princeton.edu
-prodigy_logging: verbose
+prodigy_local_envs:
+  PRODIGY_LOGGING: "verbose"
+#  PRODIGY_ALLOWED_SESSIONS: "{{ vault_prodigy_sessions }}"


### PR DESCRIPTION
The production and staging configurations have been changed so that we can have more control over Prodigy-specific environment setting by using combining dictionaries of "common" Prodigy environment settings and "local" Prodigy environment settings.