### PR TITLE
escriptorium refinements: deploy specific tagged version, enable CAS authentication

### DIFF
--- a/inventory/group_vars/htr_staging/vars.yml
+++ b/inventory/group_vars/htr_staging/vars.yml
@@ -29,7 +29,8 @@ python_version: "3.11"
 node_version: "18"
 # install local customizations as an extra package
 python_extra_packages:
-  - git+https://github.com/Princeton-CDH/htr2hpc.git@cas-login#egg=htr2hpc
+  # 19a3fca = vm-stats branch
+  - git+https://github.com/Princeton-CDH/htr2hpc.git@19a3fca#egg=htr2hpc
 
 # pul deploy user
 deploy_user: "conan"

--- a/inventory/group_vars/htr_staging/vars.yml
+++ b/inventory/group_vars/htr_staging/vars.yml
@@ -4,6 +4,10 @@ application_url: https://test-htr.princeton.edu
 
 # Git repository (on gitlab instead of github, so need to specify the full repo url)
 repo_url: https://gitlab.com/scripta/escriptorium.git
+# staging default branch is develop; install a specific tag for testing/documenting
+gitref: dev-0.14.2
+
+
 # repo variable is still needed for checkout file structure
 repo: scripta/escriptorium
 # name of django application
@@ -64,6 +68,7 @@ django_local_settings_template: "escriptorium_settings.py.j2"
 
 deploy_env_vars:
   DJANGO_SETTINGS_MODULE: escriptorium.local_settings
+  VERSION_DATE: "{{ gitref }}"  # deployed version, for display on home page
 
 # single deploy path - no versioning, no nesting
 deploy: "{{ install_root }}"

--- a/inventory/group_vars/htr_staging/vars.yml
+++ b/inventory/group_vars/htr_staging/vars.yml
@@ -23,6 +23,9 @@ symlink: "{{ app_name }}"
 python_version: "3.11"
 # nodejs version
 node_version: "18"
+# install local customizations as an extra package
+python_extra_packages:
+  - git+https://github.com/Princeton-CDH/htr2hpc.git@cas-login#egg=htr2hpc
 
 # pul deploy user
 deploy_user: "conan"

--- a/playbooks/escriptorium.yml
+++ b/playbooks/escriptorium.yml
@@ -24,6 +24,10 @@
     - name: Restart supervisor apps to load any python/django configuration changes
       ansible.builtin.command: "sudo supervisorctl restart {{ item.name }}"
       loop: "{{ supervisor_programs }}"
+    - name: Notify handler to restart nginx
+      ansible.builtin.meta: noop
+      notify:
+        - Restart nginx
   environment:
     # escriptorium local settings REPLACES default settings, must be specified
     # via env var for django manage commands to pick up

--- a/roles/django/templates/escriptorium_settings.py.j2
+++ b/roles/django/templates/escriptorium_settings.py.j2
@@ -71,7 +71,7 @@ PUCAS_LDAP.update({
         "ldap3.princeton.edu",
         "ldap4.princeton.edu",
         "ldap5.princeton.edu"
-    ,
+    ],
      "SEARCH_BASE": "o=Princeton University,c=US",
      "SEARCH_FILTER": "(uid=%(user)s)",
 })

--- a/roles/django/templates/escriptorium_settings.py.j2
+++ b/roles/django/templates/escriptorium_settings.py.j2
@@ -1,5 +1,8 @@
-from escriptorium.settings import *
 from django.utils.translation import gettext_lazy as _
+
+from escriptorium.settings import *
+from htr2hpc.settings import *
+
 
 # DEBUG = True
 
@@ -60,18 +63,18 @@ DATABASES = {
 # Princeton CAS configuration (authentication, user account creation)
 # https://github.com/Princeton-CDH/django-pucas
 {% block cas_config %}
-# CAS_SERVER_URL = "https://fed.princeton.edu/cas/"
-# CAS_VERSION = "3"
-# PUCAS_LDAP.update({
-#     "SERVERS": [
-#         "ldap2.princeton.edu",
-#         "ldap3.princeton.edu",
-#         "ldap4.princeton.edu",
-#         "ldap5.princeton.edu"
-#     ],
-#     "SEARCH_BASE": "o=Princeton University,c=US",
-#     "SEARCH_FILTER": "(uid=%(user)s)",
-#})
+CAS_SERVER_URL = "https://fed.princeton.edu/cas/"
+CAS_VERSION = "3"
+PUCAS_LDAP.update({
+    "SERVERS": [
+        "ldap2.princeton.edu",
+        "ldap3.princeton.edu",
+        "ldap4.princeton.edu",
+        "ldap5.princeton.edu"
+    ,
+     "SEARCH_BASE": "o=Princeton University,c=US",
+     "SEARCH_FILTER": "(uid=%(user)s)",
+})
 {% endblock %}
 
 # Email configuration (error messages, admin notifications)


### PR DESCRIPTION
- deploy a tagged version of escriptorium
- set environment variable so the tag will be displayed as the version on the homepage
- install new htr2hpc package as an additional python dependency for customizing the install
- use htr2hpc in local settings and configure CAS authentication