### PR TITLE
update molecule docker driver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ansible>=6.7
-molecule[docker]
+molecule-plugins[docker]
 ansible-lint
 passlib
 wheel

--- a/roles/example/.ansible-lint
+++ b/roles/example/.ansible-lint
@@ -1,0 +1,14 @@
+---
+skip_list:
+  - ANSIBLE0002
+  - ANSIBLE0006
+  - ANSIBLE0010
+  - ANSIBLE0016
+  - '303'
+  - '305'
+  - '306'
+  - '403'
+  - '503'
+  - '204'
+use_default_rules: true
+verbosity: 1

--- a/roles/example/.yamllint
+++ b/roles/example/.yamllint
@@ -1,0 +1,14 @@
+---
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  # NOTE(retr0h): Templates no longer fail this lint rule.
+  #               Uncomment if running old Molecule templates.
+  # truthy: disable

--- a/roles/example/meta/main.yml
+++ b/roles/example/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  role_name: <role_name>
+  company: Princeton University Library
+  description: <Role Description>
+  author: pulibrary
+
+  license: MIT
+
+  min_ansible_version: 2.2
+
+  platforms:
+    - name: Ubuntu
+      versions:
+        - jammy
+dependencies:
+  - role: "<role I depend on>"

--- a/roles/example/molecule/default/converge.yml
+++ b/roles/example/molecule/default/converge.yml
@@ -1,0 +1,15 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    - running_on_server: false
+  become: true
+  pre_tasks:
+    - name: Update cache
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 600
+  tasks:
+    - name: "Include example"
+      ansible.builtin.include_role:
+        name: example

--- a/roles/example/molecule/default/molecule.yml
+++ b/roles/example/molecule/default/molecule.yml
@@ -1,0 +1,22 @@
+---
+scenario:
+  name: default
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+platforms:
+  - name: instance
+    image: "ghcr.io/pulibrary/pul_containers:jammy_multi"
+    command: "sleep infinity"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  log: true
+verifier:
+  name: ansible

--- a/roles/example/molecule/default/verify.yml
+++ b/roles/example/molecule/default/verify.yml
@@ -1,0 +1,20 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Check ruby package status
+      ansible.builtin.package:
+        name: "{{ item }}"
+        state: present
+      check_mode: true
+      register: pkg_status
+      loop:
+        - ruby-switch
+        - ruby2.6-dev
+        - ruby2.6
+
+    - name: Test for ruby packages
+      ansible.builtin.assert:
+        that:
+          - not pkg_status.changed


### PR DESCRIPTION
we use `molecule-plugin[docker]` to install the docker driver used by
molecule 5.0
and an example directory with the meta and files needed by molecule to
run

related to #45

Co-authored-by: Beck Davis <beck-davis@users.noreply.github.com>
Co-authored-by: Vickie Karasic <vickiekarasic@users.noreply.github.com>
