### PR TITLE
Correct the zookeeper host string for zk upload of configset for Solr 9

### DIFF
--- a/inventory/group_vars/geniza_production/vars.yml
+++ b/inventory/group_vars/geniza_production/vars.yml
@@ -12,7 +12,7 @@ metadata_backup_gitrepo: "git@github.com:princetongenizalab/pgp-metadata.git"
 
 
 # solr 9 production settings
-zk_host: "lib-zk4:2181,lib-zk5:2181,lib-zk6:2181/solr9"
+zk_host: "lib-zk4:2181,lib-zk5:2181,lib-zk6:2181"
 solr_url: "http://lib-solr9-prod.princeton.edu:8983/solr/"
 solr_server: "{{ groups['solr9_production'][0] }}"
 

--- a/inventory/group_vars/geniza_staging/vars.yml
+++ b/inventory/group_vars/geniza_staging/vars.yml
@@ -9,7 +9,7 @@ passenger_server_name: "{{ application_url }}"
 
 # solr settings
 # geniza is using solr 9, so must override default staging solr 8 config
-zk_host: "lib-zk-staging4:2181,lib-zk-staging5:2181,lib-zk-staging6:2181/solr9"
+zk_host: "lib-zk-staging4:2181,lib-zk-staging5:2181,lib-zk-staging6:2181"
 solr_url: "http://lib-solr9-staging.princeton.edu:8983/solr/"
 solr_server: "{{ groups['solr9_staging'][0] }}"
 solr_version: 9

--- a/inventory/group_vars/prosody_production/vars.yml
+++ b/inventory/group_vars/prosody_production/vars.yml
@@ -4,7 +4,7 @@
 ---
 
 # solr 9 production settings
-zk_host: "lib-zk4:2181,lib-zk5:2181,lib-zk6:2181/solr9"
+zk_host: "lib-zk4:2181,lib-zk5:2181,lib-zk6:2181"
 solr_url: "http://lib-solr9-prod.princeton.edu:8983/solr/"
 solr_server: "{{ groups['solr9_production'][0] }}"
 

--- a/inventory/group_vars/prosody_staging/vars.yml
+++ b/inventory/group_vars/prosody_staging/vars.yml
@@ -15,7 +15,7 @@ passenger_server_name: "{{ application_url }}"
 replication_source_host: prosody_production
 
 # PPA now using solr 9, so must override default staging solr 8 config
-zk_host: "lib-zk-staging4:2181,lib-zk-staging5:2181,lib-zk-staging6:2181/solr9"
+zk_host: "lib-zk-staging4:2181,lib-zk-staging5:2181,lib-zk-staging6:2181"
 solr_url: "http://lib-solr9-staging.princeton.edu:8983/solr/"
 solr_server: "{{ groups['solr9_staging'][0] }}"
 solr_version: 9


### PR DESCRIPTION
resolves #226


On solr 9 the command line zk upload command used to create/update a configset requires this change to the zk host string.