### PR TITLE
Update shxco deploy for solr 9 (#258)

### DIFF
--- a/inventory/group_vars/shxco/vars.yml
+++ b/inventory/group_vars/shxco/vars.yml
@@ -54,6 +54,7 @@ django_local_settings_template: "shxco_settings.py.j2"
 # - solr settings
 solr_collection: cdh_shxco
 solr_configset: cdh_shxco
+solr_version: 9
 
 # github contexts required for deploy production
 # deploy_contexts:

--- a/inventory/group_vars/shxco_production/vars.yml
+++ b/inventory/group_vars/shxco_production/vars.yml
@@ -4,10 +4,11 @@
 ---
 # email_prefix for admin emails
 email_prefix: "[S&co] "
-# - solr settings
-zk_host: "lib-zk1:2181,lib-zk2:2181,lib-zk3:2181/solr8"
-solr_url: "http://lib-solr8-prod.princeton.edu:8983/solr/"
-solr_server: "{{ groups['solr_production'][0] }}"
+
+# solr 9 production settings
+zk_host: "lib-zk4:2181,lib-zk5:2181,lib-zk6:2181"
+solr_url: "http://lib-solr9-prod.princeton.edu:8983/solr/"
+solr_server: "{{ groups['solr9_production'][0] }}"
 
 # override default deploy contexts to match current CI on GitHub Actions
 deploy_contexts:

--- a/inventory/group_vars/shxco_staging/vars.yml
+++ b/inventory/group_vars/shxco_staging/vars.yml
@@ -27,3 +27,10 @@ crontab:
     hour: 2
     job: "bin/cron-wrapper {{ deploy }}/env/bin/python {{ deploy }}/manage.py twitterbot_100years schedule  >> {{ logging_dir }}/twitterbot_100years.log  2>&1"
     state: absent
+
+# solr settings
+# shxco is using solr 9, so must override default staging solr 8 config
+zk_host: "lib-zk-staging4:2181,lib-zk-staging5:2181,lib-zk-staging6:2181"
+solr_url: "http://lib-solr9-staging.princeton.edu:8983/solr/"
+solr_server: "{{ groups['solr9_staging'][0] }}"
+solr_version: 9

--- a/playbooks/shxco.yml
+++ b/playbooks/shxco.yml
@@ -2,7 +2,7 @@
 # by default this playbook runs in the staging environment
 # to run in production, pass '-e runtime_env=production'
 - name: create solr connection
-  hosts: solr_{{ runtime_env | default('staging') }}
+  hosts: solr9_{{ runtime_env | default('staging') }}
   connection: ssh
   remote_user: pulsys
   vars:


### PR DESCRIPTION
## In this PR

Per #258:
- Update the vars and playbook for S&Co. to use the solr 9 variables and host settings
- Modeled after geniza and ppa settings