### PR TITLE
Update S&Co config for Django split settings

### DIFF
--- a/inventory/group_vars/shxco/vars.yml
+++ b/inventory/group_vars/shxco/vars.yml
@@ -48,6 +48,8 @@ application_dbuser_password: "{{ vault_db_password }}"
 application_db_name: cdh_shxco
 application_db_host: "{{ postgres_host }}"
 
+# local settings is at a slightly different path (using django-split-settings)
+django_local_settings_dest: "{{ deploy }}/{{ django_app }}/settings/local_settings.py"
 # app-specific local settings
 django_local_settings_template: "shxco_settings.py.j2"
 

--- a/roles/django/templates/shxco_settings.py.j2
+++ b/roles/django/templates/shxco_settings.py.j2
@@ -2,7 +2,7 @@
 
 {% block extra_config %}
 {# Add static root as needed now because missing from settings.py as of 0.7 #}
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+STATIC_ROOT = BASE_DIR / "static"
 # Separate Geonames for usage reasons
 GEONAMES_USERNAME = '{{ geonames_username }}'
 # Media settings for running under nginx in production and QA


### PR DESCRIPTION
**Associated Issue(s):** Princeton-CDH/mep-django#849

### Changes in this PR

- Update path to local settings in `shxco/vars.yml`
- Update settings template to not rely on `os` import
