### PR TITLE
Update shxco config to use Python 3.12 (#265)

### DIFF
--- a/inventory/group_vars/shxco/vars.yml
+++ b/inventory/group_vars/shxco/vars.yml
@@ -13,8 +13,8 @@ django_app: "{{ python_app }}"
 symlink: mep
 # wsgi file relative to deploy location
 wsgi_path: "{{ django_app }}/wsgi.py"
-# use python 3.9
-python_version: 3.9
+# use python 3.12
+python_version: 3.12
 # nodejs version
 node_version: "18"
 


### PR DESCRIPTION
**Associated Issue(s):** #265

### Changes in this PR

- Set `python_version` in shxco group_vars
