### PR TITLE
Handle distutils/setuptools for python 3.12 (#265)

### DIFF
--- a/inventory/group_vars/shxco/vars.yml
+++ b/inventory/group_vars/shxco/vars.yml
@@ -78,8 +78,6 @@ app_dependencies:
   - at # for 100 years twitter bot scheduled tweets
   - libmysqlclient-dev # for mysql installation during the migration
 
-# 2to3 support needed for installing rdflib-jsonld
-requires_python2to3: true
 # datadog app/service name
 datadog_app_name: cdh_shxco
 

--- a/roles/python/tasks/install_python.yml
+++ b/roles/python/tasks/install_python.yml
@@ -21,6 +21,14 @@
       - python3-setuptools
       - python{{ python_version }}
       - python{{ python_version }}-venv
+    state: latest
+    update_cache: true
+
+- name: Install distutils for python < 3.12
+  become: true
+  ansible.builtin.apt:
+    name:
       - python{{ python_version }}-distutils
     state: latest
     update_cache: true
+  when: python_version is version('3.12', '<')


### PR DESCRIPTION
**Associated Issue(s):** #265

### Changes in this PR

- Ensure distutils package is only installed for python < 3.12, as it was [removed from python](https://docs.python.org/3/library/distutils.html) in that version.
   - Prevent error on S&Co:
     `fatal: [cdh-test-shxco1.princeton.edu]: FAILED! => {"changed": false, "msg": "No package matching 'python3.12-distutils' is available"}`

### Notes

- Is there a way I can test this before running it in tower? Should I just do the resync and then run off this branch before merging? I imagine we want to make sure it doesn't break other scripts using this task…
- Hopefully I got the ansible yaml syntax right, it's still new to me (had to look up how to ensure that `python_version` is compared correctly using [this test](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/version_test.html))
- I also removed `requires_python2to3` as I don't think that's true anymore for S&Co, and it would lock setuptools to an older version.