### PR TITLE
Update crontab role to support weekday; update prosody vars to specify weekday correctly

### DIFF
--- a/inventory/group_vars/prosody_production/vars.yml
+++ b/inventory/group_vars/prosody_production/vars.yml
@@ -24,7 +24,7 @@ crontab:
     # run at 2am on the first Saturday of every month
     minute: 0
     hour: 2
-    weekday: "SAT"
+    weekday: 6   # 0-6 for Sunday-Saturday
     day: "1-7"
     job: "bin/cron-wrapper {{ deploy }}/env/bin/python {{ deploy }}/manage.py index_pages -p 4 --gale >> {{ logging_dir }}/cron_reindex_gale_pages.log  2>&1"
     state: present

--- a/roles/configure_crontab/tasks/main.yml
+++ b/roles/configure_crontab/tasks/main.yml
@@ -19,6 +19,7 @@
       minute: "{{ item.minute | default('*') }}"
       hour: "{{ item.hour | default('*')}}"
       day: "{{ item.day | default('*')}}"
+      weekday: "{{ item.weekday | default('*')}}"
       month: "{{ item.month | default('*')}}"
       job: "{{ item.job }}"
       user: "{{ deploy_user }}"


### PR DESCRIPTION
### Changes in this PR

- configure_crontab role now supports weekday configuration in host vars
- prosody variables updated to specify numeric weekday

### Notes

- Fixed to correct a bug that was found in production - cron job was running every week day for the first of the month, instead of on Saturdays only as intended.
- Playbook has already been run with the crontab tag to update the cron job with the corrected configuration. I checked the resulting config with [crontab.guru](https://crontab.guru/#0_2_1-7_*_6)

