### PR TITLE
Set python version to 3.12 for PPA (#264)

### DIFF
--- a/inventory/group_vars/prosody/vars.yml
+++ b/inventory/group_vars/prosody/vars.yml
@@ -14,8 +14,8 @@ django_app: "{{ app_name }}"
 symlink: "{{ app_name }}"
 # wsgi file relative to deploy location
 wsgi_path: "{{ django_app }}/wsgi.py"
-# use python 3.11
-python_version: 3.11
+# use python 3.12
+python_version: 3.12
 # nodejs version
 node_version: "18"
 


### PR DESCRIPTION
**Associated Issue(s):** #264

### Changes in this PR

- Change `python_version` to 3.12 for PPA upgrades
