### PR TITLE
Add DocRaptor to prosody settings (#270)

### DIFF
--- a/inventory/group_vars/prosody/vars.yml
+++ b/inventory/group_vars/prosody/vars.yml
@@ -88,3 +88,5 @@ datadog_app_name: cdh_prosody
 # configure scripts to run as cron jobs
 crontab: []
 # currently production only
+
+docraptor_limit_note: "Limited to 5 PDFs per month."

--- a/roles/django/templates/prosody_settings.py.j2
+++ b/roles/django/templates/prosody_settings.py.j2
@@ -46,5 +46,12 @@ SHOW_TEST_WARNING = True
 CSP_SCRIPT_SRC += ("plausible.io",)
 CSP_CONNECT_SRC += ("plausible.io",)
 
+# Configure to allow DocRaptor PDF generation for Editorial pages in Wagtail.
+DOCRAPTOR_API_KEY = '{{ docraptor_api_key }}'
+
+# A note that will display next to DocRaptor PDF generation buttons on the
+# Editorial edit page. If unset, reads "Limited to 5 PDFs per month." Only
+# displayed if DOCRAPTOR_API_KEY is configured.
+DOCRAPTOR_LIMIT_NOTE = '{{ docraptor_limit_note }}'
 
 {% endblock %}


### PR DESCRIPTION
**Associated Issue(s):** #270

### Changes in this PR

- Add DocRaptor settings to ppa template, add `docraptor_limit_note` to ppa group vars

### Notes

- We still need to add an API key, presumably to the vault. I'm guessing these should be separate for prod and staging, and should both be connected in some way to CDH accounts?