### PR TITLE
Upgrade python (3.12) and node (22) on geniza

### DIFF
--- a/inventory/group_vars/geniza/vars.yml
+++ b/inventory/group_vars/geniza/vars.yml
@@ -15,10 +15,10 @@ django_app: "{{ app_name }}"
 symlink: "{{ app_name }}"
 # wsgi file relative to apache location
 wsgi_path: "{{ django_app }}/wsgi.py"
-# use python 3.9
-python_version: "3.9"
+# use python 3.12
+python_version: "3.12"
 # nodejs version
-node_version: "16"
+node_version: "22"
 
 # Override clone root to use deploy user home instead of root
 clone_root: "/home/{{ deploy_user }}/repos"


### PR DESCRIPTION
**Associated Issue(s):** https://github.com/Princeton-CDH/geniza/issues/853

### Changes in this PR

- Bump the python version to 3.12 and the node version to 22 for geniza in Ansible vars

### Notes

- According to this comment, it looks like we may have to manually upgrade node on the server:
https://github.com/Princeton-CDH/cdh-ansible/blob/013fd75dfa9c857d025b97b02c95e2072166264a/roles/build_npm/tasks/main.yml#L22-L25
  But we can try running the deploy playbook as usual first and do the manual upgrade if it fails.