### PR TITLE
Configure a pre-commit hook to validate github action workflow files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,10 @@ repos:
       language: python
       files: "inventory/group_vars/.*/vault.yml"
       additional_dependencies: ['pyyaml', 'ansible']
+  - repo: https://github.com/mpalmer/action-validator
+    rev: v0.8.0
+    hooks:
+      - id: action-validator
   # this looks potentially useful, flags fake passwords in postgres config
   # but there seems to be a yaml parsing error, maybe this:
   # https://github.com/Yelp/detect-secrets/issues/374


### PR DESCRIPTION
**Associated Issue(s):** ~

### Changes in this PR

- Configures [action-validator](https://github.com/mpalmer/action-validator?tab=readme-ov-file) to run as a pre-commit hook